### PR TITLE
#131 [feat]: living catalogue of API response-warning strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Key files: `models.py` (API contract) · `db/tables.py` (schema) · `core/countr
 - Response models use geography-neutral names: `region`, `postal_code`
 - `standardized` field: two-space separator between logical address lines (USPS single-line convention)
 - Address input capped at 1000 chars (`Field(max_length=1000)`)
-- `warnings: list[str]` on all response models; empty on clean input
+- `warnings: list[str]` on all response models; empty on clean input. Every warning string is defined in `core/warnings.py` (single source of truth) and catalogued in `docs/WARNINGS.md`; a drift test enforces sync — never inline a new warning literal
 - `components` takes precedence over `address` when both supplied
 - All request models accepting a country must inherit `CountryRequestMixin`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project uses semantic versioning.
 
+## [Unreleased]
+
+### Changed (breaking)
+
+- **Response warning string spelling normalized to American English** ([#131](https://github.com/CannObserv/address-validator/issues/131)). The standardize warning `"Unrecognised province/territory: '...'"` is now `"Unrecognized province/territory: '...'"`. Consumers matching this string in the `warnings` channel must update. All response-warning strings are now defined in `core/warnings.py` and documented in the living catalogue [`docs/WARNINGS.md`](docs/WARNINGS.md); a drift test fails CI if the two diverge.
+
 ## [3.0.0] — 2026-06-03
 
 ### Removed (breaking)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ The `type` field is one of `"Street Address"`, `"Intersection"`, or
 silently modified during parsing — for example when parenthesized text
 is stripped, when repeated address numbers are joined into a range, or
 when a unit designator is recovered from a mis-tagged field.  It is
-empty on clean input.
+empty on clean input.  See [`docs/WARNINGS.md`](docs/WARNINGS.md) for the
+authoritative catalogue of every string that may appear in `warnings`.
 
 The `components` field is a `ComponentSet` containing:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The `country` field is optional (defaults to `"US"`).
   },
   "type": "Street Address",
   "warnings": [],
-  "api_version": "1"
+  "api_version": "2"
 }
 ```
 
@@ -153,7 +153,7 @@ ignored.
     }
   },
   "warnings": [],
-  "api_version": "1"
+  "api_version": "2"
 }
 ```
 
@@ -167,7 +167,7 @@ single-line format convention.
 **Response:**
 
 ```json
-{"status": "ok", "api_version": "1"}
+{"status": "ok", "api_version": "2"}
 ```
 
 No authentication required.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,7 @@ models.py           API contract source of truth; StandardizedAddress = Standard
 core/address_format.py  build_validated_string — canonical single-line address string builder; shared across validation providers and the router layer
 core/countries.py  SUPPORTED_COUNTRIES (US+CA), VALID_ISO2 frozensets; check_country() — canonical home for country validation used by all v2 routes
 core/errors.py     APIError exception class; api_error_response() — serialises APIError to JSONResponse; registered in main.py exception handler; imported by all router layers
+core/warnings.py   single source of truth for response `warnings` strings (static constants + str.format templates + CATALOGUE tuple); catalogued in docs/WARNINGS.md, kept in sync by tests/unit/test_warnings_catalogue.py
 services/spec.py                 ISO 19160-4 spec identifiers (ISO_19160_4_SPEC, ISO_19160_4_SPEC_VERSION); used by v2 routers; USPS Pub 28 identifiers remain in usps_data/spec.py
 services/component_profiles.py  ISO 19160-4 ↔ USPS Pub28 key translation; translate_components() / translate_components_to_iso(); VALID_PROFILES frozenset; identity pass-through for unknown profiles/keys
 services/validation/pipeline.py  parse → standardize → provider-selection pipeline; build_non_us_std() (shared passthrough std for non-US components), run_us_pipeline() (US path, accepts component_profile param), run_non_us_pipeline() (CA raw strings via libpostal, other non-US via components-only); all return (std, raw_input, provider); raises APIError on validation failures

--- a/docs/WARNINGS.md
+++ b/docs/WARNINGS.md
@@ -1,0 +1,38 @@
+# API Response Warnings
+
+Authoritative, living catalogue of every string that may appear in a response
+`warnings: list[str]` field. Consumers parsing `warnings` should treat this
+table as the reference for the strings they may receive.
+
+**Source of truth:** all strings are defined in
+[`core/warnings.py`](../src/address_validator/core/warnings.py). This document
+and that module are kept in sync by the drift test
+[`tests/unit/test_warnings_catalogue.py`](../tests/unit/test_warnings_catalogue.py),
+which fails CI if either side gains or loses an entry. To add or change a
+warning, edit `core/warnings.py` and this table together.
+
+Parameterised entries use `{name}` placeholders (`str.format` fields); the
+literal token at runtime is interpolated from the offending input.
+
+This catalogue covers the **response `warnings` channel only**. Operational
+`logger.warning(...)` events are a separate channel and are documented in
+[`LOGGING.md`](LOGGING.md), not here.
+
+> Supersedes the point-in-time design snapshot
+> `docs/plans/2026-03-08-warnings-design.md`.
+
+## Catalogue
+
+| Template | Emitting module | Trigger condition |
+|---|---|---|
+| `Parenthesized text removed: '{text}'` | `services/parser.py` | Parenthetical content stripped from the input before parsing; `{text}` is the removed inner text. |
+| `Ambiguous parse: repeated address numbers joined as range '{range}'` | `services/parser.py` | Two address numbers were detected and joined into a single range; `{range}` is the joined value. |
+| `Ambiguous parse: repeated labels detected; parse may be inaccurate.` | `services/parser.py` | usaddress emitted duplicate component labels; the parse may be unreliable. |
+| `Unit designator recovered from mis-tagged field: '{designator}'` | `services/parser.py` | A unit designator was found in a mis-tagged field and reassigned; `{designator}` is the recovered token. |
+| `Unit identifier fragment recovered from city field` | `services/parser.py` | A unit identifier fragment was found in the city/locality field and moved to the unit. |
+| `Unrecognized unit designator preserved: '{designator}'` | `services/parser.py` | A unit-type token not in `UNIT_MAP` was preserved as-is (GH #129); `{designator}` is the token. |
+| `Address has no parseable street line; passing raw input to provider` | `services/validation/pipeline.py` | No street line could be parsed; the raw input is forwarded to the validation provider. |
+| `Unrecognized province/territory: '{region}'` | `services/standardizer.py` | A Canadian province/territory value was not recognized and is passed through unchanged; `{region}` is the value. |
+| `Provider inferred one or more address components not present in input` | `services/validation/google_provider.py` | The Google provider inferred components absent from the input. |
+| `Provider replaced one or more address components` | `services/validation/google_provider.py` | The Google provider replaced one or more input components. |
+| `One or more address components are unconfirmed` | `services/validation/google_provider.py` | The Google provider could not confirm one or more components. |

--- a/docs/WARNINGS.md
+++ b/docs/WARNINGS.md
@@ -36,3 +36,4 @@ This catalogue covers the **response `warnings` channel only**. Operational
 | `Provider inferred one or more address components not present in input` | `services/validation/google_provider.py` | The Google provider inferred components absent from the input. |
 | `Provider replaced one or more address components` | `services/validation/google_provider.py` | The Google provider replaced one or more input components. |
 | `One or more address components are unconfirmed` | `services/validation/google_provider.py` | The Google provider could not confirm one or more components. |
+| `Validation provider rejected the address as malformed` | `routers/v2/validate.py` | The validation provider raised a bad-request error (`ProviderBadRequestError`); the address is returned with `validation.status = "error"`. |

--- a/docs/plans/2026-03-08-warnings-design.md
+++ b/docs/plans/2026-03-08-warnings-design.md
@@ -1,5 +1,10 @@
 # Warnings Design — Issue #1
 
+> **Superseded (GH #131).** This is a point-in-time design snapshot. The living
+> catalogue of response-warning strings is now [`docs/WARNINGS.md`](../WARNINGS.md),
+> kept in sync with [`core/warnings.py`](../../src/address_validator/core/warnings.py)
+> by a drift test. Consult those, not this doc, for the current warning set.
+
 ## Summary
 
 Return a `warnings: list[str]` field on parse and standardize responses whenever

--- a/src/address_validator/core/warnings.py
+++ b/src/address_validator/core/warnings.py
@@ -11,6 +11,11 @@ channel and are intentionally NOT catalogued here.
 Keep this module and ``docs/WARNINGS.md`` in sync — the drift test
 ``tests/unit/test_warnings_catalogue.py`` fails on any divergence. After
 adding or changing a warning, update both.
+
+This module must contain **only** warning string constants (plus ``CATALOGUE``):
+the drift test treats every module-level upper-case ``str`` as a catalogued
+warning, so an incidental non-warning string constant here would be a false
+positive. Put unrelated constants elsewhere.
 """
 
 # --- Static warnings (no interpolation) ---
@@ -21,6 +26,7 @@ NO_PARSEABLE_STREET = "Address has no parseable street line; passing raw input t
 PROVIDER_INFERRED = "Provider inferred one or more address components not present in input"
 PROVIDER_REPLACED = "Provider replaced one or more address components"
 PROVIDER_UNCONFIRMED = "One or more address components are unconfirmed"
+PROVIDER_REJECTED_MALFORMED = "Validation provider rejected the address as malformed"
 
 # --- Parameterised warnings (str.format templates) ---
 
@@ -45,4 +51,5 @@ CATALOGUE: tuple[str, ...] = (
     PROVIDER_INFERRED,
     PROVIDER_REPLACED,
     PROVIDER_UNCONFIRMED,
+    PROVIDER_REJECTED_MALFORMED,
 )

--- a/src/address_validator/core/warnings.py
+++ b/src/address_validator/core/warnings.py
@@ -1,0 +1,48 @@
+"""Single source of truth for API response-warning strings (GH #131).
+
+Every string appended to a response ``warnings: list[str]`` field is defined
+here — nowhere else. Static warnings are plain string constants; parameterised
+warnings are ``str.format`` templates with named placeholders, so the wording
+is fixed in one place and call sites only supply the variable token.
+
+This is distinct from ``logger.warning(...)`` calls, which are an operational
+channel and are intentionally NOT catalogued here.
+
+Keep this module and ``docs/WARNINGS.md`` in sync — the drift test
+``tests/unit/test_warnings_catalogue.py`` fails on any divergence. After
+adding or changing a warning, update both.
+"""
+
+# --- Static warnings (no interpolation) ---
+
+REPEATED_LABELS = "Ambiguous parse: repeated labels detected; parse may be inaccurate."
+UNIT_FRAGMENT_FROM_CITY = "Unit identifier fragment recovered from city field"
+NO_PARSEABLE_STREET = "Address has no parseable street line; passing raw input to provider"
+PROVIDER_INFERRED = "Provider inferred one or more address components not present in input"
+PROVIDER_REPLACED = "Provider replaced one or more address components"
+PROVIDER_UNCONFIRMED = "One or more address components are unconfirmed"
+
+# --- Parameterised warnings (str.format templates) ---
+
+PARENTHESIZED_REMOVED = "Parenthesized text removed: '{text}'"
+REPEATED_NUMBERS_RANGE = "Ambiguous parse: repeated address numbers joined as range '{range}'"
+UNIT_RECOVERED_FROM_FIELD = "Unit designator recovered from mis-tagged field: '{designator}'"
+UNRECOGNIZED_UNIT_DESIGNATOR = "Unrecognized unit designator preserved: '{designator}'"
+UNRECOGNIZED_REGION = "Unrecognized province/territory: '{region}'"
+
+# Authoritative list of every catalogued response warning. The drift test
+# checks this against docs/WARNINGS.md in both directions, so a new warning is
+# only "live" once it appears here.
+CATALOGUE: tuple[str, ...] = (
+    PARENTHESIZED_REMOVED,
+    REPEATED_NUMBERS_RANGE,
+    REPEATED_LABELS,
+    UNIT_RECOVERED_FROM_FIELD,
+    UNIT_FRAGMENT_FROM_CITY,
+    UNRECOGNIZED_UNIT_DESIGNATOR,
+    NO_PARSEABLE_STREET,
+    UNRECOGNIZED_REGION,
+    PROVIDER_INFERRED,
+    PROVIDER_REPLACED,
+    PROVIDER_UNCONFIRMED,
+)

--- a/src/address_validator/routers/v2/validate.py
+++ b/src/address_validator/routers/v2/validate.py
@@ -43,6 +43,7 @@ import math
 from fastapi import APIRouter, Depends, Query
 
 from address_validator.auth import require_api_key
+from address_validator.core import warnings as warning_catalogue
 from address_validator.core.errors import APIError
 from address_validator.models import (
     ErrorResponse,
@@ -156,11 +157,10 @@ async def validate_address(
     except ProviderBadRequestError as exc:
         logger.warning("Validation provider %s rejected request", exc.provider)
         set_audit_context(provider=exc.provider, validation_status="error", cache_hit=False)
-        warnings = ["Validation provider rejected the address as malformed"]
         result = ValidateResponseV2(
             country=std.country,
             validation=ValidationResult(status="error", provider=exc.provider),
-            warnings=std.warnings + warnings,
+            warnings=[*std.warnings, warning_catalogue.PROVIDER_REJECTED_MALFORMED],
         )
         return result
     except ProviderRateLimitedError as exc:

--- a/src/address_validator/services/parser.py
+++ b/src/address_validator/services/parser.py
@@ -5,6 +5,7 @@ import re
 
 import usaddress
 
+from address_validator.core import warnings as warning_catalogue
 from address_validator.models import ComponentSet, ParseResponseV2
 from address_validator.services.audit import set_audit_context
 from address_validator.services.libpostal_client import (
@@ -211,7 +212,9 @@ def _collect_ambiguous_components(
                     redirect_id_key = slot[1]
                     if not known_designator:
                         warnings.append(
-                            f"Unrecognized unit designator preserved: '{cleaned_unit_token}'"
+                            warning_catalogue.UNRECOGNIZED_UNIT_DESIGNATOR.format(
+                                designator=cleaned_unit_token
+                            )
                         )
                     prev_key = key
                     separator_before = False
@@ -235,9 +238,9 @@ def _collect_ambiguous_components(
         prev_key = key
 
     if dual_range is not None:
-        warnings.append(f"Ambiguous parse: repeated address numbers joined as range '{dual_range}'")
+        warnings.append(warning_catalogue.REPEATED_NUMBERS_RANGE.format(range=dual_range))
     else:
-        warnings.append("Ambiguous parse: repeated labels detected; parse may be inaccurate.")
+        warnings.append(warning_catalogue.REPEATED_LABELS)
 
     return component_values
 
@@ -249,7 +252,7 @@ def _warn_unit_recovered(warnings: list[str] | None, designator: str) -> None:
     defined in one place.  No-op when *warnings* is ``None``.
     """
     if warnings is not None:
-        warnings.append(f"Unit designator recovered from mis-tagged field: '{designator}'")
+        warnings.append(warning_catalogue.UNIT_RECOVERED_FROM_FIELD.format(designator=designator))
 
 
 def _recover_unit_phase1(
@@ -381,7 +384,7 @@ def _recover_identifier_fragment_from_city(
             components[key] += f" {fragment}"
             components["locality"] = rest
             if warnings is not None:
-                warnings.append("Unit identifier fragment recovered from city field")
+                warnings.append(warning_catalogue.UNIT_FRAGMENT_FROM_CITY)
             return
 
 
@@ -440,7 +443,7 @@ def _parse(raw: str, country: str) -> ParseResponseV2:
     for match in paren_matches:
         inner = match[1:-1].strip()
         if inner:
-            warnings.append(f"Parenthesized text removed: '{inner}'")
+            warnings.append(warning_catalogue.PARENTHESIZED_REMOVED.format(text=inner))
 
     try:
         tagged, addr_type = usaddress.tag(cleaned)

--- a/src/address_validator/services/standardizer.py
+++ b/src/address_validator/services/standardizer.py
@@ -7,6 +7,7 @@ from address_validator.canada_post_data.directionals import CA_DIRECTIONAL_MAP
 from address_validator.canada_post_data.provinces import PROVINCE_MAP
 from address_validator.canada_post_data.spec import CANADA_POST_SPEC, CANADA_POST_SPEC_VERSION
 from address_validator.canada_post_data.suffixes import CA_SUFFIX_MAP
+from address_validator.core import warnings as warning_catalogue
 from address_validator.core.address_format import build_validated_string
 from address_validator.models import (  # alias can't be used as constructor
     ComponentSet,
@@ -177,7 +178,7 @@ def _standardize_ca(
         if abbr:
             std["administrative_area"] = abbr
         else:
-            warnings.append(f"Unrecognised province/territory: '{region}'")
+            warnings.append(warning_catalogue.UNRECOGNIZED_REGION.format(region=region))
             std["administrative_area"] = region
 
     # --- postcode ---

--- a/src/address_validator/services/validation/google_provider.py
+++ b/src/address_validator/services/validation/google_provider.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from address_validator.core import warnings as warning_catalogue
 from address_validator.core.address_format import build_validated_string
 from address_validator.models import (
     ComponentSet,
@@ -13,10 +14,6 @@ from address_validator.services.validation.google_client import GoogleClient
 from address_validator.usps_data.spec import USPS_PUB28_SPEC, USPS_PUB28_SPEC_VERSION
 
 logger = logging.getLogger(__name__)
-
-_WARNING_INFERRED = "Provider inferred one or more address components not present in input"
-_WARNING_REPLACED = "Provider replaced one or more address components"
-_WARNING_UNCONFIRMED = "One or more address components are unconfirmed"
 
 
 class GoogleProvider:
@@ -106,11 +103,11 @@ class GoogleProvider:
 
         warnings: list[str] = []
         if raw.get("has_inferred_components"):
-            warnings.append(_WARNING_INFERRED)
+            warnings.append(warning_catalogue.PROVIDER_INFERRED)
         if raw.get("has_replaced_components"):
-            warnings.append(_WARNING_REPLACED)
+            warnings.append(warning_catalogue.PROVIDER_REPLACED)
         if raw.get("has_unconfirmed_components"):
-            warnings.append(_WARNING_UNCONFIRMED)
+            warnings.append(warning_catalogue.PROVIDER_UNCONFIRMED)
 
         return ValidateResponseV2(
             address_line_1=address_line_1,

--- a/src/address_validator/services/validation/pipeline.py
+++ b/src/address_validator/services/validation/pipeline.py
@@ -18,6 +18,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+from address_validator.core import warnings as warning_catalogue
 from address_validator.core.address_format import build_validated_string
 from address_validator.core.countries import VALID_ISO2
 from address_validator.core.errors import APIError
@@ -111,7 +112,7 @@ async def run_us_pipeline(
         and req.address.strip()
         and not std.address_line_1.strip()
     ):
-        fallback_warning = "Address has no parseable street line; passing raw input to provider"
+        fallback_warning = warning_catalogue.NO_PARSEABLE_STREET
         raw_street = re.sub(r"\s+", " ", req.address).strip()
         std = std.model_copy(
             update={

--- a/tests/integration/test_v2_validate.py
+++ b/tests/integration/test_v2_validate.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from address_validator.core import warnings as warning_catalogue
 from address_validator.main import app
 from address_validator.models import ValidateResponseV2, ValidationResult
 from address_validator.services.validation.errors import ProviderBadRequestError
@@ -67,7 +68,7 @@ class TestV2ValidateUnparseableInput:
             latitude=47.8253139,
             longitude=-122.2936207,
             validation=ValidationResult(status="invalid", provider="google"),
-            warnings=["Provider inferred one or more address components not present in input"],
+            warnings=[warning_catalogue.PROVIDER_INFERRED],
         )
         provider = AsyncMock()
         provider.validate = AsyncMock(return_value=google_response)
@@ -105,3 +106,4 @@ class TestV2ValidateUnparseableInput:
         body = response.json()
         assert body["validation"]["status"] == "error"
         assert body["validation"]["provider"] == "google"
+        assert warning_catalogue.PROVIDER_REJECTED_MALFORMED in body["warnings"]

--- a/tests/unit/services/test_standardizer.py
+++ b/tests/unit/services/test_standardizer.py
@@ -379,7 +379,7 @@ class TestStandardizeCA:
             "postcode": "A1A 1A1",
         }
         result = standardize(comps, country="CA")
-        assert any("Unrecognised" in w for w in result.warnings)
+        assert any("Unrecognized" in w for w in result.warnings)
         assert result.components.values["administrative_area"] == "XX"
 
     def test_directional_normalised(self) -> None:

--- a/tests/unit/test_warnings_catalogue.py
+++ b/tests/unit/test_warnings_catalogue.py
@@ -42,27 +42,83 @@ def _module_string_constants() -> dict[str, str]:
     }
 
 
+def _is_str_literal(node: ast.AST) -> bool:
+    """A string ``Constant`` or an f-string (``JoinedStr``)."""
+    return isinstance(node, ast.JoinedStr) or (
+        isinstance(node, ast.Constant) and isinstance(node.value, str)
+    )
+
+
+def _contains_str_literal(node: ast.AST) -> bool:
+    """True if *node* is a str literal, or a list/tuple/set holding one."""
+    if _is_str_literal(node):
+        return True
+    if isinstance(node, ast.List | ast.Tuple | ast.Set):
+        return any(_is_str_literal(elt) for elt in node.elts)
+    return False
+
+
+def _targets_warnings(node: ast.AST) -> bool:
+    """True if *node* refers to a ``warnings`` list — either a bare name
+    ``warnings`` or any attribute access ending in ``.warnings`` (e.g.
+    ``result.warnings``, ``std.warnings``)."""
+    return (isinstance(node, ast.Name) and node.id == "warnings") or (
+        isinstance(node, ast.Attribute) and node.attr == "warnings"
+    )
+
+
 def _inline_warning_literals() -> list[str]:
-    """Find ``warnings.append(<str literal>)`` / ``.append(f"...")`` call sites
-    anywhere under ``src/`` — these bypass the catalogue and must not exist."""
+    """Find any string literal that flows into a ``warnings`` list anywhere
+    under ``src/`` — these bypass the catalogue and must not exist.
+
+    Covers the realistic vectors:
+    - ``warnings.append("...")`` / ``.append(f"...")``
+    - ``warnings.extend([...])``
+    - ``warnings = ["...", ...]`` (incl. annotated assignment)
+    - ``Response(warnings=["..."])`` keyword argument
+    - ``{"warnings": ["..."]}`` dict literal (e.g. ``model_copy`` update)
+    """
     violations: list[str] = []
     for path in SRC_ROOT.rglob("*.py"):
         if path == WARNINGS_MODULE:
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "append"
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "warnings"
-                and node.args
-                and isinstance(node.args[0], ast.Constant | ast.JoinedStr)
-            ):
+            if _flows_str_literal_into_warnings(node):
                 rel = path.relative_to(REPO_ROOT)
                 violations.append(f"{rel}:{node.lineno}")
     return violations
+
+
+def _flows_str_literal_into_warnings(node: ast.AST) -> bool:
+    """True if *node* puts a string literal into a ``warnings`` list."""
+    # warnings.append(<literal>) / warnings.extend([<literal>, ...])
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ("append", "extend")
+        and _targets_warnings(node.func.value)
+        and node.args
+    ):
+        return _contains_str_literal(node.args[0])
+    # The value bound to a `warnings` target, via the supported binding forms.
+    bound_value: ast.AST | None = None
+    if isinstance(node, ast.Assign) and any(_targets_warnings(t) for t in node.targets):
+        bound_value = node.value  # warnings = [<literal>, ...]
+    elif isinstance(node, ast.AnnAssign) and _targets_warnings(node.target):
+        bound_value = node.value  # warnings: list[str] = [<literal>, ...]
+    elif isinstance(node, ast.keyword) and node.arg == "warnings":
+        bound_value = node.value  # foo(warnings=[<literal>, ...])
+    if bound_value is not None:
+        return _contains_str_literal(bound_value)
+    # {"warnings": [<literal>, ...]} dict literal (e.g. model_copy update)
+    if isinstance(node, ast.Dict):
+        return any(
+            isinstance(k, ast.Constant) and k.value == "warnings" and _contains_str_literal(v)
+            for k, v in zip(node.keys, node.values, strict=True)
+            if k is not None
+        )
+    return False
 
 
 def test_doc_exists() -> None:

--- a/tests/unit/test_warnings_catalogue.py
+++ b/tests/unit/test_warnings_catalogue.py
@@ -1,0 +1,50 @@
+"""Drift guard for the response-warning catalogue (GH #131).
+
+Asserts bidirectional sync between the single source of truth
+(:mod:`address_validator.core.warnings`) and the consumer-facing catalogue
+(``docs/WARNINGS.md``):
+
+- every warning template defined in code is documented, and
+- every documented template maps back to a live code template.
+
+If you add or change a response warning, update both ``core/warnings.py`` and
+``docs/WARNINGS.md`` — this test fails on any divergence.
+"""
+
+import re
+from pathlib import Path
+
+from address_validator.core import warnings as warning_catalogue
+
+WARNINGS_DOC = Path(__file__).resolve().parents[2] / "docs" / "WARNINGS.md"
+
+
+def _documented_templates() -> set[str]:
+    """Extract warning templates from the backtick-quoted first column of the
+    catalogue table in ``docs/WARNINGS.md``."""
+    text = WARNINGS_DOC.read_text(encoding="utf-8")
+    templates: set[str] = set()
+    for row in re.finditer(r"^\|\s*`([^`]+)`\s*\|", text, flags=re.MULTILINE):
+        templates.add(row.group(1))
+    return templates
+
+
+def test_doc_exists():
+    assert WARNINGS_DOC.is_file(), f"missing catalogue doc: {WARNINGS_DOC}"
+
+
+def test_catalogue_is_nonempty():
+    assert warning_catalogue.CATALOGUE, "CATALOGUE must list every response warning"
+
+
+def test_every_code_warning_is_documented():
+    documented = _documented_templates()
+    missing = [w for w in warning_catalogue.CATALOGUE if w not in documented]
+    assert not missing, f"warnings defined in code but absent from docs/WARNINGS.md: {missing}"
+
+
+def test_every_documented_warning_exists_in_code():
+    documented = _documented_templates()
+    catalogue = set(warning_catalogue.CATALOGUE)
+    orphaned = [w for w in documented if w not in catalogue]
+    assert not orphaned, f"warnings documented but absent from core/warnings.py: {orphaned}"

--- a/tests/unit/test_warnings_catalogue.py
+++ b/tests/unit/test_warnings_catalogue.py
@@ -11,12 +11,16 @@ If you add or change a response warning, update both ``core/warnings.py`` and
 ``docs/WARNINGS.md`` — this test fails on any divergence.
 """
 
+import ast
 import re
 from pathlib import Path
 
 from address_validator.core import warnings as warning_catalogue
 
-WARNINGS_DOC = Path(__file__).resolve().parents[2] / "docs" / "WARNINGS.md"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WARNINGS_DOC = REPO_ROOT / "docs" / "WARNINGS.md"
+SRC_ROOT = REPO_ROOT / "src" / "address_validator"
+WARNINGS_MODULE = SRC_ROOT / "core" / "warnings.py"
 
 
 def _documented_templates() -> set[str]:
@@ -29,22 +33,73 @@ def _documented_templates() -> set[str]:
     return templates
 
 
-def test_doc_exists():
+def _module_string_constants() -> dict[str, str]:
+    """Every module-level upper-case ``str`` constant in ``core/warnings.py``."""
+    return {
+        name: value
+        for name, value in vars(warning_catalogue).items()
+        if name.isupper() and isinstance(value, str)
+    }
+
+
+def _inline_warning_literals() -> list[str]:
+    """Find ``warnings.append(<str literal>)`` / ``.append(f"...")`` call sites
+    anywhere under ``src/`` — these bypass the catalogue and must not exist."""
+    violations: list[str] = []
+    for path in SRC_ROOT.rglob("*.py"):
+        if path == WARNINGS_MODULE:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "append"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "warnings"
+                and node.args
+                and isinstance(node.args[0], ast.Constant | ast.JoinedStr)
+            ):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{node.lineno}")
+    return violations
+
+
+def test_doc_exists() -> None:
     assert WARNINGS_DOC.is_file(), f"missing catalogue doc: {WARNINGS_DOC}"
 
 
-def test_catalogue_is_nonempty():
+def test_catalogue_is_nonempty() -> None:
     assert warning_catalogue.CATALOGUE, "CATALOGUE must list every response warning"
 
 
-def test_every_code_warning_is_documented():
+def test_every_code_warning_is_documented() -> None:
     documented = _documented_templates()
     missing = [w for w in warning_catalogue.CATALOGUE if w not in documented]
     assert not missing, f"warnings defined in code but absent from docs/WARNINGS.md: {missing}"
 
 
-def test_every_documented_warning_exists_in_code():
+def test_every_documented_warning_exists_in_code() -> None:
     documented = _documented_templates()
     catalogue = set(warning_catalogue.CATALOGUE)
     orphaned = [w for w in documented if w not in catalogue]
     assert not orphaned, f"warnings documented but absent from core/warnings.py: {orphaned}"
+
+
+def test_every_module_constant_is_in_catalogue() -> None:
+    """A warning string constant added to the module but omitted from
+    ``CATALOGUE`` would ship undocumented — guard against it."""
+    catalogue = set(warning_catalogue.CATALOGUE)
+    missing = {
+        name: value for name, value in _module_string_constants().items() if value not in catalogue
+    }
+    assert not missing, f"warning constants missing from CATALOGUE: {sorted(missing)}"
+
+
+def test_no_inline_warning_literals_in_src() -> None:
+    """All response warnings must come from ``core/warnings.py`` — no call site
+    may append a bare string/f-string literal to a ``warnings`` list."""
+    violations = _inline_warning_literals()
+    assert not violations, (
+        f"inline warning literals found (use core/warnings.py constants instead): {violations}"
+    )


### PR DESCRIPTION
Closes #131.

## Summary

Establishes a living catalogue of API response-`warnings` strings, backed by a single source of truth and a CI drift guard — so the documentation can no longer rot out of sync with the code (the failure mode that motivated #131).

- **`core/warnings.py`** — single source of truth: every response-`warnings` string as a named static constant or `str.format` template, plus a `CATALOGUE` tuple. All call sites (parser, standardizer, pipeline, google_provider, validate router) now reference it; zero inline literals remain in `src/`.
- **`docs/WARNINGS.md`** — consumer-facing catalogue (template · emitting module · trigger). Old `docs/plans/2026-03-08-warnings-design.md` marked superseded; AGENTS.md, ARCHITECTURE.md, and README cross-linked.
- **`tests/unit/test_warnings_catalogue.py`** — drift guard: catalogue ↔ doc (both directions), every module constant ∈ `CATALOGUE`, and an AST guard rejecting any inline string literal flowing into a `warnings` list anywhere in `src/`.

## Notable finds

- The catalogue is **12 warnings**, not the 7 listed in the issue — the AST guard surfaced a previously-uncatalogued warning in `validate.py` (`"Validation provider rejected the address as malformed"`) that the original grep missed because it was a `warnings = [...]` assignment, not `.append`.

## Breaking change

- Warning spelling normalized to American English: `"Unrecognised province/territory: '...'"` → `"Unrecognized province/territory: '...'"`. Consumers matching this string in the `warnings` channel must update. Noted in CHANGELOG under `[Unreleased]`.

## Verification

- Full suite: 925 passed, coverage 94.68% (floor 80%).
- ruff check + format clean; JS lint/format/tests clean.
- Three rounds of `/code-review` applied (guard strengthening, doc fixes, behavioral assertion for the router-emitted warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)