### PR TITLE
#155 [feat]: USPS_API_BASE env override for USPS API base URL

### DIFF
--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -9,6 +9,7 @@
 | `USPS_CONSUMER_SECRET` | string | — | USPS OAuth2 client secret |
 | `USPS_RATE_LIMIT_RPS` | float ≥ 1 | `5.0` | USPS per-second soft window |
 | `USPS_DAILY_LIMIT` | positive int | `10000` | USPS per-day soft window |
+| `USPS_API_BASE` | http(s) URL | `https://apis.usps.com` | Scheme+host for USPS API; override for TEM (`https://apis-tem.usps.com`) or Enhanced API host switch (#155). Paths (`/oauth2/v3/token`, `/addresses/v3/address`) are fixed. |
 | `GOOGLE_PROJECT_ID` | string | — | GCP project; auto-discovered from ADC if unset |
 | `GOOGLE_RATE_LIMIT_RPM` | positive int | `5` | Google per-minute soft window |
 | `GOOGLE_DAILY_LIMIT` | positive int | `160` | Auto-discovered from Cloud Quotas; env var is fallback |

--- a/src/address_validator/services/validation/config.py
+++ b/src/address_validator/services/validation/config.py
@@ -46,6 +46,17 @@ class USPSConfig(BaseSettings):
     consumer_secret: str
     rate_limit_rps: float = 5.0
     daily_limit: int = 10000
+    # Override for TEM (apis-tem.usps.com) or the Enhanced Addresses API
+    # host switch (GH #155); path suffixes stay fixed in usps_client.py.
+    api_base: str = "https://apis.usps.com"
+
+    @field_validator("api_base")
+    @classmethod
+    def _api_base_is_http_url(cls, v: str) -> str:
+        v = v.rstrip("/")
+        if not v.startswith(("https://", "http://")):
+            raise ValueError("USPS_API_BASE must be an http(s) URL (e.g. 'https://apis.usps.com')")
+        return v
 
     @field_validator("rate_limit_rps")
     @classmethod

--- a/src/address_validator/services/validation/registry.py
+++ b/src/address_validator/services/validation/registry.py
@@ -147,6 +147,7 @@ class ProviderRegistry:
                 consumer_secret=cfg.consumer_secret,
                 http_client=self._get_http_client(),
                 quota_guard=guard,
+                api_base=cfg.api_base,
             )
         )
         return self._usps_provider

--- a/src/address_validator/services/validation/usps_client.py
+++ b/src/address_validator/services/validation/usps_client.py
@@ -35,8 +35,9 @@ _ZIP5_LENGTH = 5
 
 logger = logging.getLogger(__name__)
 
-_TOKEN_URL = "https://apis.usps.com/oauth2/v3/token"  # noqa: S105
-_ADDRESS_URL = "https://apis.usps.com/addresses/v3/address"
+_DEFAULT_API_BASE = "https://apis.usps.com"
+_TOKEN_PATH = "/oauth2/v3/token"  # noqa: S105
+_ADDRESS_PATH = "/addresses/v3/address"
 
 # Token is refreshed 60 s before it actually expires to avoid races.
 _TOKEN_REFRESH_BUFFER_S = 60
@@ -119,6 +120,10 @@ class USPSClient:
     quota_guard:
         A :class:`~services.validation._rate_limit.QuotaGuard` instance
         for rate limiting.
+    api_base:
+        Scheme+host prefix for the USPS API (no trailing slash). Defaults to
+        production; override via ``USPS_API_BASE`` for TEM or an endpoint
+        host switch (GH #155).
     """
 
     # Class-level dedup set for recon logging (issue #122). Spans the
@@ -132,6 +137,7 @@ class USPSClient:
         consumer_secret: str,
         http_client: httpx.AsyncClient,
         quota_guard: QuotaGuard,
+        api_base: str = _DEFAULT_API_BASE,
     ) -> None:
         self._consumer_key = consumer_key
         self._consumer_secret = consumer_secret
@@ -139,6 +145,8 @@ class USPSClient:
         self._token: USPSToken | None = None
         self._token_lock = asyncio.Lock()
         self._rate_limiter = quota_guard
+        self._token_url = f"{api_base}{_TOKEN_PATH}"
+        self._address_url = f"{api_base}{_ADDRESS_PATH}"
 
     @classmethod
     def _reset_recon_state(cls) -> None:
@@ -163,7 +171,7 @@ class USPSClient:
 
             logger.debug("USPSClient: fetching new OAuth2 token")
             resp = await self._http.post(
-                _TOKEN_URL,
+                self._token_url,
                 data={
                     "grant_type": "client_credentials",
                     "client_id": self._consumer_key,
@@ -238,7 +246,7 @@ class USPSClient:
             await self._rate_limiter.acquire()
             token = await self._get_token()
             resp = await self._http.get(
-                _ADDRESS_URL,
+                self._address_url,
                 headers={"Authorization": f"Bearer {token}"},
                 params=params,
             )

--- a/tests/unit/validation/test_config.py
+++ b/tests/unit/validation/test_config.py
@@ -66,6 +66,34 @@ class TestUSPSConfig:
         cfg = USPSConfig()
         assert cfg.daily_limit == 5000
 
+    def test_default_api_base(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USPS_CONSUMER_KEY", "k")
+        monkeypatch.setenv("USPS_CONSUMER_SECRET", "s")
+        monkeypatch.delenv("USPS_API_BASE", raising=False)
+        cfg = USPSConfig()
+        assert cfg.api_base == "https://apis.usps.com"
+
+    def test_custom_api_base(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USPS_CONSUMER_KEY", "k")
+        monkeypatch.setenv("USPS_CONSUMER_SECRET", "s")
+        monkeypatch.setenv("USPS_API_BASE", "https://apis-tem.usps.com")
+        cfg = USPSConfig()
+        assert cfg.api_base == "https://apis-tem.usps.com"
+
+    def test_api_base_trailing_slash_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USPS_CONSUMER_KEY", "k")
+        monkeypatch.setenv("USPS_CONSUMER_SECRET", "s")
+        monkeypatch.setenv("USPS_API_BASE", "https://apis-tem.usps.com/")
+        cfg = USPSConfig()
+        assert cfg.api_base == "https://apis-tem.usps.com"
+
+    def test_api_base_without_scheme_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USPS_CONSUMER_KEY", "k")
+        monkeypatch.setenv("USPS_CONSUMER_SECRET", "s")
+        monkeypatch.setenv("USPS_API_BASE", "apis.usps.com")
+        with pytest.raises(ValueError, match="USPS_API_BASE"):
+            USPSConfig()
+
 
 class TestGoogleConfig:
     def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/validation/test_registry.py
+++ b/tests/unit/validation/test_registry.py
@@ -56,6 +56,19 @@ class TestGetProvider:
         assert isinstance(result, CachingProvider)
         assert isinstance(result._inner, USPSProvider)
 
+    def test_usps_api_base_reaches_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        reg = _make_registry(
+            monkeypatch,
+            VALIDATION_PROVIDER="usps",
+            USPS_CONSUMER_KEY="key",
+            USPS_CONSUMER_SECRET="secret",
+            USPS_API_BASE="https://apis-tem.usps.com",
+        )
+        result = reg.get_provider()
+        client = result._inner.client
+        assert client._address_url == "https://apis-tem.usps.com/addresses/v3/address"
+        assert client._token_url == "https://apis-tem.usps.com/oauth2/v3/token"
+
     def test_usps_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         reg = _make_registry(
             monkeypatch,

--- a/tests/unit/validation/test_usps_client.py
+++ b/tests/unit/validation/test_usps_client.py
@@ -108,6 +108,35 @@ class TestUSPSClient:
         assert mock_http.get.call_count == 1  # address call
 
     @pytest.mark.asyncio
+    async def test_default_api_base_urls(self, client: USPSClient, mock_http: AsyncMock) -> None:
+        mock_http.post.return_value = self._make_response(TOKEN_RESPONSE)
+        mock_http.get.return_value = self._make_response(VALID_ADDRESS_RESPONSE)
+
+        await client.validate_address("123 Main St", "Springfield", "IL")
+
+        assert mock_http.post.call_args[0][0] == "https://apis.usps.com/oauth2/v3/token"
+        assert mock_http.get.call_args[0][0] == "https://apis.usps.com/addresses/v3/address"
+
+    @pytest.mark.asyncio
+    async def test_custom_api_base_urls(
+        self, mock_http: AsyncMock, _default_guard: QuotaGuard
+    ) -> None:
+        client = USPSClient(
+            consumer_key="key",
+            consumer_secret="secret",
+            http_client=mock_http,
+            quota_guard=_default_guard,
+            api_base="https://apis-tem.usps.com",
+        )
+        mock_http.post.return_value = self._make_response(TOKEN_RESPONSE)
+        mock_http.get.return_value = self._make_response(VALID_ADDRESS_RESPONSE)
+
+        await client.validate_address("123 Main St", "Springfield", "IL")
+
+        assert mock_http.post.call_args[0][0] == "https://apis-tem.usps.com/oauth2/v3/token"
+        assert mock_http.get.call_args[0][0] == "https://apis-tem.usps.com/addresses/v3/address"
+
+    @pytest.mark.asyncio
     async def test_reuses_cached_token(self, client: USPSClient, mock_http: AsyncMock) -> None:
         mock_http.post.return_value = self._make_response(TOKEN_RESPONSE)
         mock_http.get.return_value = self._make_response(VALID_ADDRESS_RESPONSE)


### PR DESCRIPTION
## Summary
- `USPS_API_BASE` env var (default `https://apis.usps.com`, unchanged behavior) on `USPSConfig`; validated http(s) URL, trailing slash stripped
- `USPSClient` builds token/address URLs from injected `api_base`; paths fixed (`/oauth2/v3/token`, `/addresses/v3/address`)
- Registry threads `cfg.api_base` through to the client
- Env table entry in `docs/VALIDATION-PROVIDERS.md`

Approach A from `docs/plans/2026-07-02-usps-enhanced-api-switch-design.md` — endpoint-host optionality for the 2026-07-12 Enhanced Addresses API switch (#155). No parse/standardize output change → no `PIPELINE_CODE_VERSION` bump.

## Test plan
- New: config default/override/trailing-slash/bad-scheme; client default+custom URL assertions; registry pass-through
- `uv run pytest` full suite: 1011 passed, coverage 94.92%
- `uv run ruff check .` + format: clean

Part of #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)