### PR TITLE
#155 [fix]: CR round 1 — canary hardening, api_base normalization, doc fixes

### DIFF
--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -86,14 +86,11 @@ curl -s http://localhost:8000/api/v2/health | jq .
 ```
 
 Restore `VALIDATION_PROVIDER=usps,google` (and restart) once the license is
-active and a manual token probe succeeds:
+active and a canary run comes back clean (exit 0; reads prod creds itself):
 
 ```bash
-# Token probe (uses prod creds; run from a shell that has NOT sourced .env into pytest scope)
-curl -s -X POST https://apis.usps.com/oauth2/v3/token \
-  -d "grant_type=client_credentials" \
-  -d "client_id=$USPS_CONSUMER_KEY" \
-  -d "client_secret=$USPS_CONSUMER_SECRET" | jq 'has("access_token")'
+scripts/usps_canary.sh && echo "USPS probes OK"
+# per-probe detail in scratch/usps-canary.log
 ```
 
 During a Google-only gap: `validation.provider="google"` on all rows,

--- a/docs/plans/2026-07-02-usps-enhanced-api-switch-design.md
+++ b/docs/plans/2026-07-02-usps-enhanced-api-switch-design.md
@@ -100,3 +100,21 @@ Daily 07-10 → 07-20:
   becomes binding limit during gap.
 - **Fees/tier unknown** → operator reviews order form; `USPS_DAILY_LIMIT`
   may need lowering to fit purchased tier.
+
+## Addendum (2026-07-02, post-implementation)
+
+Two design assumptions were overtaken by events the same day:
+
+- **The Enhanced Addresses API spec IS published** — v3.3.1, linked from the
+  portal as `enhanced-addresses-v3r2.yaml`; vendored at
+  `docs/usps-enhanced-addresses-v3r2.yaml` (PR #157). Same servers and
+  `/address` path; `DPVConfirmation` (Y/D/S/N) and `vacant` retained →
+  **current provider needs no code change for the switch**. `state` request
+  param now optional; `business` deprecated (not consumed). New
+  `additionalInfo` indicators catalogued on #122.
+- **Canary is a crontab shell script**, not a scheduled agent:
+  `scripts/usps_canary.sh`, crontab `23 14 10-20 7 *`. Cloud agents cannot
+  reach the production creds or this VM; session-local scheduling does not
+  survive to the window. Script exits non-zero on anomaly and comments on
+  GH #155.
+- `USPS_API_BASE` shipped in PR #156.

--- a/docs/usps-pub28.md
+++ b/docs/usps-pub28.md
@@ -28,11 +28,12 @@ Attempts to determine the exact edition:
    of research.
 
 3. **Cross-reference against USPS Addresses API v3** — The USPS Addresses API
-   v3.2.2 OpenAPI spec (now archived as `usps-addresses-v3r2_4.yaml`, API
-   version 3.2.3 — same content for this purpose) links to
-   `pe.usps.com/text/pub28/28c2_003.htm` for secondary unit designator
-   definitions, confirming Pub 28 is the normative reference for the API.  The
-   spec's `version: 3.2.2` refers to the API revision, not the Pub 28 edition.
+   OpenAPI spec (v3.2.2 at research time; the archived
+   `usps-addresses-v3r2_4.yaml` copy is v3.2.3, identical for this purpose)
+   links to `pe.usps.com/text/pub28/28c2_003.htm` for secondary unit
+   designator definitions, confirming Pub 28 is the normative reference for
+   the API.  The spec `version` refers to the API revision, not the Pub 28
+   edition.
 
 ### Current `spec_version` value
 

--- a/scripts/usps_canary.sh
+++ b/scripts/usps_canary.sh
@@ -13,6 +13,7 @@
 #
 # Logs to scratch/usps-canary.log (gitignored). Comments on GH #155 when any
 # probe fails or drifts — and unconditionally on July 12 (switch day).
+# Exits 1 when any probe recorded an anomaly, 0 otherwise.
 set -u
 
 REPO="/home/exedev/address-validator"
@@ -28,11 +29,13 @@ getvar() { grep "^$1=" "$2" | head -1 | cut -d= -f2-; }
 mkdir -p "$(dirname "$LOG")"
 note "--- canary run"
 
-# 1. OAuth token probe
+# 1. OAuth token probe — creds passed via a curl config file on stdin-style
+# process substitution so they never appear in the process argv.
 KEY=$(getvar USPS_CONSUMER_KEY "$PROD_ENV")
 SECRET=$(getvar USPS_CONSUMER_SECRET "$PROD_ENV")
 TOKEN=$(curl -s -m 20 -X POST https://apis.usps.com/oauth2/v3/token \
-  -d grant_type=client_credentials -d "client_id=$KEY" -d "client_secret=$SECRET" |
+  -d grant_type=client_credentials \
+  --config <(printf 'data-urlencode = "client_id=%s"\ndata-urlencode = "client_secret=%s"\n' "$KEY" "$SECRET") |
   python3 -c 'import json,sys;print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
 if [ -n "$TOKEN" ]; then
   note "oauth: ok"
@@ -43,11 +46,11 @@ fi
 
 # 2. Direct address validation (USPS HQ; public address, no PII)
 if [ -n "$TOKEN" ]; then
-  BODY=/tmp/usps_canary_addr.json
+  BODY=$(mktemp /tmp/usps_canary_addr.XXXXXX)
   HTTP=$(curl -s -m 20 -o "$BODY" -w '%{http_code}' \
     -H "Authorization: Bearer $TOKEN" \
     "https://apis.usps.com/addresses/v3/address?streetAddress=475%20LENFANT%20PLZ%20SW&city=WASHINGTON&state=DC")
-  DPV=$(python3 -c 'import json;print(json.load(open("/tmp/usps_canary_addr.json")).get("additionalInfo",{}).get("DPVConfirmation",""))' 2>/dev/null)
+  DPV=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("additionalInfo",{}).get("DPVConfirmation",""))' "$BODY" 2>/dev/null)
   if [ "$HTTP" = "200" ] && [ -n "$DPV" ]; then
     note "address: ok (dpv=$DPV)"
   else
@@ -61,7 +64,7 @@ fi
 for SPEC in addresses-v3r2_4:usps-addresses-v3r2_4 enhanced-addresses-v3r2:usps-enhanced-addresses-v3r2; do
   REMOTE="${SPEC%%:*}.yaml"
   LOCAL="$REPO/docs/${SPEC##*:}.yaml"
-  TMP="/tmp/usps_canary_spec.yaml"
+  TMP=$(mktemp /tmp/usps_canary_spec.XXXXXX)
   if curl -s -m 20 -o "$TMP" "$SPEC_BASE/$REMOTE" && [ -s "$TMP" ] && head -1 "$TMP" | grep -q openapi; then
     if cmp -s "$TMP" "$LOCAL"; then
       note "spec $REMOTE: ok"
@@ -103,3 +106,5 @@ if [ ${#ANOMALIES[@]} -gt 0 ] || [ "$(date -u +%m-%d)" = "07-12" ]; then
   } | gh --repo CannObserv/address-validator issue comment 155 --body-file - >/dev/null &&
     note "report: commented on #155" || note "report: gh comment FAILED"
 fi
+
+[ ${#ANOMALIES[@]} -eq 0 ]

--- a/src/address_validator/services/validation/usps_client.py
+++ b/src/address_validator/services/validation/usps_client.py
@@ -121,9 +121,9 @@ class USPSClient:
         A :class:`~services.validation._rate_limit.QuotaGuard` instance
         for rate limiting.
     api_base:
-        Scheme+host prefix for the USPS API (no trailing slash). Defaults to
-        production; override via ``USPS_API_BASE`` for TEM or an endpoint
-        host switch (GH #155).
+        Scheme+host prefix for the USPS API (trailing slash tolerated).
+        Defaults to production; override via ``USPS_API_BASE`` for TEM or an
+        endpoint host switch (GH #155).
     """
 
     # Class-level dedup set for recon logging (issue #122). Spans the
@@ -145,6 +145,7 @@ class USPSClient:
         self._token: USPSToken | None = None
         self._token_lock = asyncio.Lock()
         self._rate_limiter = quota_guard
+        api_base = api_base.rstrip("/")
         self._token_url = f"{api_base}{_TOKEN_PATH}"
         self._address_url = f"{api_base}{_ADDRESS_PATH}"
 

--- a/tests/unit/validation/test_usps_client.py
+++ b/tests/unit/validation/test_usps_client.py
@@ -137,6 +137,25 @@ class TestUSPSClient:
         assert mock_http.get.call_args[0][0] == "https://apis-tem.usps.com/addresses/v3/address"
 
     @pytest.mark.asyncio
+    async def test_api_base_trailing_slash_normalised(
+        self, mock_http: AsyncMock, _default_guard: QuotaGuard
+    ) -> None:
+        client = USPSClient(
+            consumer_key="key",
+            consumer_secret="secret",
+            http_client=mock_http,
+            quota_guard=_default_guard,
+            api_base="https://apis-tem.usps.com/",
+        )
+        mock_http.post.return_value = self._make_response(TOKEN_RESPONSE)
+        mock_http.get.return_value = self._make_response(VALID_ADDRESS_RESPONSE)
+
+        await client.validate_address("123 Main St", "Springfield", "IL")
+
+        assert mock_http.post.call_args[0][0] == "https://apis-tem.usps.com/oauth2/v3/token"
+        assert mock_http.get.call_args[0][0] == "https://apis-tem.usps.com/addresses/v3/address"
+
+    @pytest.mark.asyncio
     async def test_reuses_cached_token(self, client: USPSClient, mock_http: AsyncMock) -> None:
         mock_http.post.return_value = self._make_response(TOKEN_RESPONSE)
         mock_http.get.return_value = self._make_response(VALID_ADDRESS_RESPONSE)


### PR DESCRIPTION
CR round 1 directives on the #155 work (PRs #156/#157):

1. Design doc addendum — Enhanced spec published + crontab canary reality
2. Runbook token-probe snippet → points at `scripts/usps_canary.sh`
3. Canary: creds via curl `--config` process substitution (off argv)
4. Canary: `mktemp` for temp files; body path via `sys.argv`
5. Canary: exits 1 on anomaly
6. `usps-pub28.md` version-sentence reword
7. `USPSClient` normalizes trailing slash on `api_base` (+ test)

Verification: 1012 passed / 94.92% cov, ruff clean; live canary run exit 0 all probes ok; anomaly path tested with stubbed `gh` + bogus creds → exit 1.

Part of #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)