### PR TITLE
#155 [docs]: cutover time 10am CT Jul 12; canary shifted post-cutover

### DIFF
--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -60,15 +60,17 @@ When a provider is rate-limited (HTTP 429 after all retries), the next provider 
 
 Effective 2026-07-12 USPS requires a signed Addressing API License Agreement +
 Order Form + Enterprise Payment System (EPS) account, with consumption
-tier-based fees. Design doc: `docs/plans/2026-07-02-usps-enhanced-api-switch-design.md`.
+tier-based fees. **Cutover: 2026-07-12 10:00 CT (15:00 UTC). License executed
+2026-07-06.** Design doc: `docs/plans/2026-07-02-usps-enhanced-api-switch-design.md`.
 
 **Enhanced Addresses spec is published** (v3.3.1, vendored at
 `docs/usps-enhanced-addresses-v3r2.yaml`): same servers and `/address` path,
 `DPVConfirmation`/`vacant` retained — current provider works unchanged. New
 `additionalInfo` indicators are recon targets (GH #122).
 
-**Canary:** `scripts/usps_canary.sh` runs daily 14:23 UTC July 10–20 via
-crontab (`23 14 10-20 7 *`). Probes OAuth, a live `/address` call (cache
+**Canary:** `scripts/usps_canary.sh` runs daily 16:23 UTC July 10–20 via
+crontab (`23 16 10-20 7 *`) — after the 15:00 UTC cutover on switch day, so
+the July 12 run probes the post-cutover API. Probes OAuth, a live `/address` call (cache
 bypassed, no DB writes), both vendored spec checksums, and portal spec links;
 comments on GH #155 on anomaly (always on July 12). Remove the crontab entry
 after July 20.

--- a/scripts/usps_canary.sh
+++ b/scripts/usps_canary.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # USPS Enhanced Addresses API switch canary — GH #155.
 #
-# Daily crontab probe for the 2026-07-12 licensing switch (window Jul 10-20):
-#   23 14 10-20 7 * /home/exedev/address-validator/scripts/usps_canary.sh
+# Daily crontab probe for the 2026-07-12 licensing switch (window Jul 10-20;
+# cutover 2026-07-12 15:00 UTC — 16:23 runs land post-cutover on switch day):
+#   23 16 10-20 7 * /home/exedev/address-validator/scripts/usps_canary.sh
 #
 # Probes (all bypass the service cache; nothing is written to the prod DB):
 #   1. OAuth2 token endpoint with production creds


### PR DESCRIPTION
- USPS cutover confirmed 2026-07-12 10:00 CT (15:00 UTC); license agreement executed 2026-07-06
- Canary crontab moved 14:23 → 16:23 UTC (already applied on the VM) so the switch-day run probes the post-cutover API instead of reporting 37 min before it
- Runbook + script header updated to match

Part of #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)