### PR TITLE
#162 [feat]: weekly disk-hygiene timer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Quick ops (see `docs/DEPLOYMENT.md` for full reference):
 - Logs: `journalctl -u address-validator -f`
 - Re-install unit: `sudo cp infra/address-validator.service /etc/systemd/system/ && sudo systemctl daemon-reload`
 - Pre-commit hooks: `uv run pre-commit install`
+- Disk hygiene: weekly timer (`infra/disk-hygiene.sh`, Sun 05:00 UTC) prunes VS Code server builds, npm/uv caches, orphaned worktrees; dry-run with `infra/disk-hygiene.sh --dry-run`
 
 ## Infrastructure
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -33,12 +33,22 @@ sudo cp infra/docker-prune.service infra/docker-prune.timer /etc/systemd/system/
 # Validation-cache TTL sweep timer (daily 04:00 UTC)
 sudo cp infra/cache-sweep.service infra/cache-sweep.timer /etc/systemd/system/ \
   && sudo systemctl daemon-reload && sudo systemctl enable --now cache-sweep.timer
+
+# Disk hygiene timer (weekly, Sun 05:00 UTC)
+sudo cp infra/disk-hygiene.service infra/disk-hygiene.timer /etc/systemd/system/ \
+  && sudo systemctl daemon-reload && sudo systemctl enable --now disk-hygiene.timer
 ```
 
 Docker prune does **not** use `-a` (active images are safe). Logs a journal warning if disk ≥ 85% after prune:
 
 ```bash
 journalctl -t docker-prune -p warning
+```
+
+Disk hygiene prunes stale VS Code server builds (keeps 2 newest + any running), old extension versions, VSIX cache >14d, npm cache + `_npx` >30d, uv/pre-commit caches, and orphaned worktree dirs (`.claude/worktrees/*`, `.worktrees/*` not in `git worktree list`). Never touches Docker, Postgres, or registered worktrees. Dry-run: `infra/disk-hygiene.sh --dry-run`. Warns in journal at ≥75% root-FS usage:
+
+```bash
+journalctl -u disk-hygiene -p info
 ```
 
 The cache sweep deletes `validated_addresses` rows (and their `query_patterns` pointers) older than `VALIDATION_CACHE_TTL_DAYS`. Dry-run any time with `PYTHONPATH=src uv run python infra/sweep_cache.py --dry-run` (`PYTHONPATH=src` is required — the package is not installed editable). Logs swept counts to the journal:

--- a/docs/plans/2026-07-09-disk-hygiene-design.md
+++ b/docs/plans/2026-07-09-disk-hygiene-design.md
@@ -1,0 +1,65 @@
+# Disk Hygiene — Scheduled Cleanup Design
+
+**Date:** 2026-07-09
+**Status:** Approved
+**Approach:** One-off prune + weekly scheduled hygiene job (approach A of A/B/C considered)
+
+## Problem
+
+Recurring disk pressure on the single-VM host (30G root FS). Audit on 2026-07-09 found 13G used (45%) with ~3.9G immediately reclaimable and several unbounded growth vectors:
+
+| Growth vector | Rate |
+|---|---|
+| VS Code remote server builds (`~/.vscode-server/cli/servers`) | ~540M per VS Code update, never evicted (5 copies found) |
+| Claude Code extension versions + VSIX cache | ~255M per update + 181M cache |
+| npm cache (`_npx` + `_cacache`) | grows per `npx` invocation (709M found) |
+| uv cache | grows per resolve (349M found) |
+| Leaked harness worktrees (`.claude/worktrees/*` with orphaned `.venv`) | ~300M per leak (1 found: issue-114) |
+
+Fixed/required: `/usr` 3.9G, Docker 2.7G (libpostal image 2.49G required for CA parsing; qdrant image+volume = SocratiCode index), repo `.venv`/`node_modules`, Postgres 340M, `claude` CLI 213M, journald (capped 8M).
+
+## Design
+
+### `scripts/ops/disk-hygiene.sh`
+
+Idempotent, `--dry-run` flag (prints deletion list, deletes nothing). Logs before/after `df -h /` line each run.
+
+| Target | Rule |
+|---|---|
+| `~/.vscode-server/cli/servers` | Keep 2 most-recent per `lru.json` and any version with a running process; delete rest |
+| `~/.vscode-server/extensions` | Per extension, keep newest version dir only |
+| `~/.vscode-server/data/CachedExtensionVSIXs` | Delete files older than 14 days |
+| `~/.npm` | `npm cache clean --force`; delete `_npx` entries older than 30 days |
+| `~/.cache/uv` | `uv cache prune` |
+| `~/.cache/pre-commit` | `pre-commit gc` |
+| Worktrees | `git worktree prune`; delete `.claude/worktrees/*` and `.worktrees/*` dirs not in `git worktree list` |
+| Threshold | Root FS ≥ 75% → log `WARNING` (surfaces in `journalctl -u disk-hygiene`) |
+
+### systemd units
+
+`infra/disk-hygiene.service` (oneshot, `User=exedev`) + `infra/disk-hygiene.timer` (`OnCalendar=weekly`, `Persistent=true`). Install: `sudo cp infra/disk-hygiene.{service,timer} /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now disk-hygiene.timer`.
+
+## Out of scope
+
+- Docker pruning — both images active, no dangling layers; skipping keeps the job non-root
+- Postgres retention (audit / training-candidate rows) — DB only 227M; revisit if a future audit shows growth
+- journald — already capped
+- Registered worktrees' `.venv`/`node_modules` — never touched
+
+## Safety
+
+- Deletes only under `~/.vscode-server`, `~/.npm`, `~/.cache`, and orphaned worktree dirs
+- VS Code server prune cross-checks running processes — cannot kill an active remote session
+- Dry-run reviewed before first real run
+
+## Testing
+
+- Shell script; outside pytest coverage scope
+- `shellcheck` clean
+- Verification: `--dry-run` review → manual run → confirm `df` delta, VS Code remote still connects, dev workflow intact
+
+## Rollout
+
+1. Implement in worktree, PR, merge
+2. Install units; `sudo systemctl start disk-hygiene`; report reclaimed space
+3. Document in `docs/DEPLOYMENT.md` ops section + AGENTS.md deployment table one-liner

--- a/docs/plans/2026-07-09-disk-hygiene-design.md
+++ b/docs/plans/2026-07-09-disk-hygiene-design.md
@@ -20,7 +20,9 @@ Fixed/required: `/usr` 3.9G, Docker 2.7G (libpostal image 2.49G required for CA 
 
 ## Design
 
-### `scripts/ops/disk-hygiene.sh`
+### `infra/disk-hygiene.sh`
+
+(Moved from `scripts/ops/` at implementation time — `infra/` is the established home for timer helper scripts: `docker-prune-check.sh`, `sweep_cache.py`, `archive_audit.py`.)
 
 Idempotent, `--dry-run` flag (prints deletion list, deletes nothing). Logs before/after `df -h /` line each run.
 

--- a/infra/disk-hygiene.service
+++ b/infra/disk-hygiene.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Prune stale VS Code server builds, dev caches, orphaned worktrees
+
+[Service]
+Type=oneshot
+User=exedev
+Environment=HOME=/home/exedev
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/exedev/address-validator/infra/disk-hygiene.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/disk-hygiene.sh
+++ b/infra/disk-hygiene.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Weekly disk hygiene: prune stale VS Code server builds and extension
+# versions, npm/uv/pre-commit caches, and orphaned worktree directories.
+# Design: docs/plans/2026-07-09-disk-hygiene-design.md
+#
+# Usage: disk-hygiene.sh [--dry-run]
+
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+fi
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VSCODE_DIR="${HOME}/.vscode-server"
+USAGE_WARN_PCT=75
+VSIX_MAX_AGE_DAYS=14
+NPX_MAX_AGE_DAYS=30
+SERVER_KEEP_COUNT=2
+
+log() { echo "disk-hygiene: $*"; }
+
+remove_path() {
+  local path=$1 size
+  [[ -e "$path" ]] || return 0
+  size=$(du -sh "$path" 2>/dev/null | cut -f1)
+  if ((DRY_RUN)); then
+    log "would remove: $path (${size})"
+  else
+    log "removing: $path (${size})"
+    rm -rf -- "$path"
+  fi
+}
+
+log "start: $(df -h --output=used,avail,pcent / | tail -1 | xargs)"
+
+# --- VS Code server builds: keep N most-recent per lru.json + any running ---
+servers_dir="${VSCODE_DIR}/cli/servers"
+if [[ -d "$servers_dir" && -f "${servers_dir}/lru.json" ]]; then
+  keep=$(jq -r ".[0:${SERVER_KEEP_COUNT}][]" "${servers_dir}/lru.json")
+  for dir in "$servers_dir"/*/; do
+    dir="${dir%/}"
+    name=$(basename "$dir")
+    if grep -qxF "$name" <<<"$keep"; then
+      continue
+    fi
+    # Never delete a build with a live server process, regardless of LRU age
+    if pgrep -f "cli/servers/${name}/" >/dev/null 2>&1; then
+      log "keeping (running): $name"
+      continue
+    fi
+    remove_path "$dir"
+  done
+fi
+
+# --- VS Code extensions: keep newest version dir per extension id ---
+ext_dir="${VSCODE_DIR}/extensions"
+if [[ -d "$ext_dir" ]]; then
+  while IFS= read -r old; do
+    remove_path "$old"
+  done < <(python3 - "$ext_dir" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+groups: dict[str, list[Path]] = {}
+for d in Path(sys.argv[1]).iterdir():
+    # publisher.name-1.2.3 or publisher.name-1.2.3-linux-x64
+    if d.is_dir() and (m := re.match(r"^(.+?)-(\d+\.\d+\.\d+.*)$", d.name)):
+        groups.setdefault(m.group(1), []).append(d)
+for dirs in groups.values():
+    dirs.sort(key=lambda p: p.stat().st_mtime)
+    for old in dirs[:-1]:
+        print(old)
+PY
+  )
+fi
+
+# --- VS Code cached VSIX downloads older than N days ---
+vsix_dir="${VSCODE_DIR}/data/CachedExtensionVSIXs"
+if [[ -d "$vsix_dir" ]]; then
+  while IFS= read -r f; do
+    remove_path "$f"
+  done < <(find "$vsix_dir" -mindepth 1 -mtime "+${VSIX_MAX_AGE_DAYS}")
+fi
+
+# --- npm: wipe registry cache; expire stale npx sandboxes ---
+if command -v npm >/dev/null 2>&1; then
+  if ((DRY_RUN)); then
+    log "would run: npm cache clean --force"
+  else
+    npm cache clean --force 2>/dev/null || log "npm cache clean failed (non-fatal)"
+  fi
+fi
+if [[ -d "${HOME}/.npm/_npx" ]]; then
+  while IFS= read -r d; do
+    remove_path "$d"
+  done < <(find "${HOME}/.npm/_npx" -mindepth 1 -maxdepth 1 -mtime "+${NPX_MAX_AGE_DAYS}")
+fi
+
+# --- uv cache: drop wheels not referenced by current environments ---
+if command -v uv >/dev/null 2>&1; then
+  if ((DRY_RUN)); then
+    log "would run: uv cache prune"
+  else
+    uv cache prune 2>/dev/null || log "uv cache prune failed (non-fatal)"
+  fi
+fi
+
+# --- pre-commit: drop hook repos unreferenced by any config ---
+if [[ -x "${REPO}/.venv/bin/pre-commit" ]]; then
+  if ((DRY_RUN)); then
+    log "would run: pre-commit gc"
+  else
+    "${REPO}/.venv/bin/pre-commit" gc 2>/dev/null || log "pre-commit gc failed (non-fatal)"
+  fi
+fi
+
+# --- orphaned worktree dirs: on disk but not registered with git ---
+if ((!DRY_RUN)); then
+  git -C "$REPO" worktree prune
+fi
+registered=$(git -C "$REPO" worktree list --porcelain | awk '/^worktree /{print $2}')
+for base in "${REPO}/.claude/worktrees" "${REPO}/.worktrees"; do
+  [[ -d "$base" ]] || continue
+  for dir in "$base"/*/; do
+    dir="${dir%/}"
+    [[ -d "$dir" ]] || continue
+    if ! grep -qxF "$dir" <<<"$registered"; then
+      remove_path "$dir"
+    fi
+  done
+done
+
+# --- usage threshold warning ---
+pct=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+if ((pct >= USAGE_WARN_PCT)); then
+  log "WARNING: root filesystem at ${pct}% (threshold ${USAGE_WARN_PCT}%)"
+fi
+
+log "end: $(df -h --output=used,avail,pcent / | tail -1 | xargs)"

--- a/infra/disk-hygiene.timer
+++ b/infra/disk-hygiene.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Weekly disk hygiene (Sun 05:00 UTC)
+
+[Timer]
+OnCalendar=Sun 05:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #162.

## What
- `infra/disk-hygiene.sh` (`--dry-run` supported): prunes VS Code server builds (keeps 2 newest per `lru.json` + any with a live process), old extension versions (newest per id kept), VSIX cache >14d, npm cache + `_npx` >30d, `uv cache prune`, `pre-commit gc`, orphaned worktree dirs under `.claude/worktrees/` and `.worktrees/` not registered with git. Logs before/after df; warns at ≥75% usage.
- `infra/disk-hygiene.service` + `.timer` — weekly Sun 05:00 UTC (after docker-prune 03:30, cache-sweep 04:00), `User=exedev`, matches existing timer conventions.
- Docs: DEPLOYMENT.md scheduled-timers section, AGENTS.md quick-ops line, design-doc path note (`infra/` not `scripts/ops/`).

## Verification
- `bash -n` clean (shellcheck not installed on VM)
- Dry-run output: keeps running + 2 newest server builds, flags 3 old builds (~1.5G), duplicate claude-code extension (254M), stale VSIX (20M)
- Orphan logic verified against main repo: flags only leaked `issue-114-google-400-mapper-fallback` (299M); active registered worktrees untouched

Design doc: `docs/plans/2026-07-09-disk-hygiene-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)