### PR TITLE
#162 [fix]: disk-hygiene fail-open on rm permission errors

### DIFF
--- a/infra/disk-hygiene.sh
+++ b/infra/disk-hygiene.sh
@@ -29,7 +29,9 @@ remove_path() {
     log "would remove: $path (${size})"
   else
     log "removing: $path (${size})"
-    rm -rf -- "$path"
+    # Fail-open: a permission error (e.g. root-owned strays) must not abort
+    # the remaining hygiene sections under set -e
+    rm -rf -- "$path" 2>/dev/null || log "WARNING: could not fully remove ${path} — check ownership"
   fi
 }
 


### PR DESCRIPTION
First live run aborted mid-script: leaked worktree .venv contained root-owned __pycache__ dirs; rm -rf failure under set -e killed the run. Now logs WARNING and continues. Root-owned strays cleaned up manually (one-off sudo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)