### PR TITLE
#162 [fix]: CR round 1 — harden disk-hygiene script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        files: ^infra/.*\.sh$
   - repo: local
     hooks:
       - id: build-tailwind-css

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,10 +45,11 @@ Docker prune does **not** use `-a` (active images are safe). Logs a journal warn
 journalctl -t docker-prune -p warning
 ```
 
-Disk hygiene prunes stale VS Code server builds (keeps 2 newest + any running), old extension versions, VSIX cache >14d, npm cache + `_npx` >30d, uv/pre-commit caches, and orphaned worktree dirs (`.claude/worktrees/*`, `.worktrees/*` not in `git worktree list`). Never touches Docker, Postgres, or registered worktrees. Dry-run: `infra/disk-hygiene.sh --dry-run`. Warns in journal at ≥75% root-FS usage:
+Disk hygiene prunes stale VS Code server builds (keeps 2 newest + any running), old extension versions, VSIX cache >14d, npm cache + `_npx` >30d, uv/pre-commit caches, and orphaned worktree dirs (`.claude/worktrees/*`, `.worktrees/*` not in `git worktree list`, aged >30min). Never touches Docker, Postgres, or registered worktrees. Dry-run: `infra/disk-hygiene.sh --dry-run`. Warnings (≥75% root-FS usage, unremovable paths, unreadable lru.json) go to the journal at real warning priority, matching docker-prune:
 
 ```bash
-journalctl -u disk-hygiene -p info
+journalctl -u disk-hygiene -p info      # full run log
+journalctl -t disk-hygiene -p warning   # warnings only
 ```
 
 The cache sweep deletes `validated_addresses` rows (and their `query_patterns` pointers) older than `VALIDATION_CACHE_TTL_DAYS`. Dry-run any time with `PYTHONPATH=src uv run python infra/sweep_cache.py --dry-run` (`PYTHONPATH=src` is required — the package is not installed editable). Logs swept counts to the journal:

--- a/infra/disk-hygiene.service
+++ b/infra/disk-hygiene.service
@@ -7,6 +7,3 @@ User=exedev
 Environment=HOME=/home/exedev
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 ExecStart=/home/exedev/address-validator/infra/disk-hygiene.sh
-
-[Install]
-WantedBy=multi-user.target

--- a/infra/disk-hygiene.sh
+++ b/infra/disk-hygiene.sh
@@ -6,7 +6,12 @@
 # Usage: disk-hygiene.sh [--dry-run]
 
 set -euo pipefail
+shopt -s nullglob
 
+if [[ $# -gt 1 || ($# -eq 1 && $1 != "--dry-run") ]]; then
+  echo "usage: ${0##*/} [--dry-run]" >&2
+  exit 2
+fi
 DRY_RUN=0
 if [[ "${1:-}" == "--dry-run" ]]; then
   DRY_RUN=1
@@ -18,20 +23,27 @@ USAGE_WARN_PCT=75
 VSIX_MAX_AGE_DAYS=14
 NPX_MAX_AGE_DAYS=30
 SERVER_KEEP_COUNT=2
+WORKTREE_MIN_AGE_MIN=30
 
 log() { echo "disk-hygiene: $*"; }
+
+warn() {
+  log "WARNING: $*"
+  # Real journal warning priority so `journalctl -p warning` and alerting see it
+  logger -p user.warning -t disk-hygiene "$*" 2>/dev/null || true
+}
 
 remove_path() {
   local path=$1 size
   [[ -e "$path" ]] || return 0
-  size=$(du -sh "$path" 2>/dev/null | cut -f1)
+  size=$(du -sh -- "$path" 2>/dev/null | cut -f1) || size="?"
   if ((DRY_RUN)); then
     log "would remove: $path (${size})"
   else
     log "removing: $path (${size})"
     # Fail-open: a permission error (e.g. root-owned strays) must not abort
     # the remaining hygiene sections under set -e
-    rm -rf -- "$path" 2>/dev/null || log "WARNING: could not fully remove ${path} — check ownership"
+    rm -rf -- "$path" 2>/dev/null || warn "could not fully remove ${path} — check ownership"
   fi
 }
 
@@ -40,23 +52,29 @@ log "start: $(df -h --output=used,avail,pcent / | tail -1 | xargs)"
 # --- VS Code server builds: keep N most-recent per lru.json + any running ---
 servers_dir="${VSCODE_DIR}/cli/servers"
 if [[ -d "$servers_dir" && -f "${servers_dir}/lru.json" ]]; then
-  keep=$(jq -r ".[0:${SERVER_KEEP_COUNT}][]" "${servers_dir}/lru.json")
-  for dir in "$servers_dir"/*/; do
-    dir="${dir%/}"
-    name=$(basename "$dir")
-    if grep -qxF "$name" <<<"$keep"; then
-      continue
-    fi
-    # Never delete a build with a live server process, regardless of LRU age
-    if pgrep -f "cli/servers/${name}/" >/dev/null 2>&1; then
-      log "keeping (running): $name"
-      continue
-    fi
-    remove_path "$dir"
-  done
+  keep=$(jq -r ".[0:${SERVER_KEEP_COUNT}][]" "${servers_dir}/lru.json" 2>/dev/null) || keep=""
+  if [[ -z "$keep" ]]; then
+    # An empty keep-list would delete every non-running build, including the
+    # newest — treat unreadable/empty lru.json as "skip this section"
+    warn "could not read keep-list from ${servers_dir}/lru.json — skipping server-build prune"
+  else
+    for dir in "$servers_dir"/*/; do
+      dir="${dir%/}"
+      name=$(basename "$dir")
+      if grep -qxF "$name" <<<"$keep"; then
+        continue
+      fi
+      # Never delete a build with a live server process, regardless of LRU age
+      if pgrep -f "cli/servers/${name}/" >/dev/null 2>&1; then
+        log "keeping (running): $name"
+        continue
+      fi
+      remove_path "$dir"
+    done
+  fi
 fi
 
-# --- VS Code extensions: keep newest version dir per extension id ---
+# --- VS Code extensions: keep highest version dir per extension id ---
 ext_dir="${VSCODE_DIR}/extensions"
 if [[ -d "$ext_dir" ]]; then
   while IFS= read -r old; do
@@ -66,14 +84,15 @@ import re
 import sys
 from pathlib import Path
 
-groups: dict[str, list[Path]] = {}
+groups: dict[str, list[tuple[tuple[int, ...], float, Path]]] = {}
 for d in Path(sys.argv[1]).iterdir():
     # publisher.name-1.2.3 or publisher.name-1.2.3-linux-x64
-    if d.is_dir() and (m := re.match(r"^(.+?)-(\d+\.\d+\.\d+.*)$", d.name)):
-        groups.setdefault(m.group(1), []).append(d)
-for dirs in groups.values():
-    dirs.sort(key=lambda p: p.stat().st_mtime)
-    for old in dirs[:-1]:
+    if d.is_dir() and (m := re.match(r"^(.+?)-(\d+\.\d+\.\d+)", d.name)):
+        version = tuple(int(x) for x in m.group(2).split("."))
+        groups.setdefault(m.group(1), []).append((version, d.stat().st_mtime, d))
+for entries in groups.values():
+    entries.sort()  # version first, mtime as tiebreak
+    for _, _, old in entries[:-1]:
         print(old)
 PY
   )
@@ -129,16 +148,23 @@ for base in "${REPO}/.claude/worktrees" "${REPO}/.worktrees"; do
   for dir in "$base"/*/; do
     dir="${dir%/}"
     [[ -d "$dir" ]] || continue
-    if ! grep -qxF "$dir" <<<"$registered"; then
-      remove_path "$dir"
+    if grep -qxF "$dir" <<<"$registered"; then
+      continue
     fi
+    # In-flight creation window: the dir can exist moments before git
+    # registers it — never sweep anything this young
+    if [[ -n "$(find "$dir" -maxdepth 0 -mmin "-${WORKTREE_MIN_AGE_MIN}")" ]]; then
+      log "keeping (recent, <${WORKTREE_MIN_AGE_MIN}min): $dir"
+      continue
+    fi
+    remove_path "$dir"
   done
 done
 
 # --- usage threshold warning ---
 pct=$(df --output=pcent / | tail -1 | tr -dc '0-9')
 if ((pct >= USAGE_WARN_PCT)); then
-  log "WARNING: root filesystem at ${pct}% (threshold ${USAGE_WARN_PCT}%)"
+  warn "root filesystem at ${pct}% (threshold ${USAGE_WARN_PCT}%)"
 fi
 
 log "end: $(df -h --output=used,avail,pcent / | tail -1 | xargs)"


### PR DESCRIPTION
CR round 1 findings 1-9 (directives: 1 fix, 2 reject, 3 fix, 4 warn, 5 fix, 6 sort, 7 skip-young, 8 drop, 9 shellcheck).

- Fail-open on du size-probe failure; unknown args rejected (exit 2)
- lru.json unreadable/empty → warn + skip server prune (previously: abort, or delete every non-running build)
- Warnings emitted via logger at real warning priority (`journalctl -t disk-hygiene -p warning`)
- nullglob; extension prune sorts by parsed version, mtime tiebreak
- Worktree sweep skips dirs <30min old (in-flight creation window)
- Service unit: dropped unnecessary [Install]
- shellcheck pre-commit hook (shellcheck-py v0.11.0.1) scoped to infra/*.sh — passing

Verified by sandbox tests (fake $HOME): version-sort, corrupt/empty lru skip, du/rm fail-open with unreadable dir, arg rejection, journal warning priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)