### PR TITLE
#162 [fix]: CR round 2 — space-safe worktree list, warn priorities, idle IO, test rig

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        files: ^infra/.*\.sh$
+        files: ^(infra|tests/shell)/.*\.sh$
   - repo: local
     hooks:
       - id: build-tailwind-css

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,7 +45,7 @@ Docker prune does **not** use `-a` (active images are safe). Logs a journal warn
 journalctl -t docker-prune -p warning
 ```
 
-Disk hygiene prunes stale VS Code server builds (keeps 2 newest + any running), old extension versions, VSIX cache >14d, npm cache + `_npx` >30d, uv/pre-commit caches, and orphaned worktree dirs (`.claude/worktrees/*`, `.worktrees/*` not in `git worktree list`, aged >30min). Never touches Docker, Postgres, or registered worktrees. Dry-run: `infra/disk-hygiene.sh --dry-run`. Warnings (≥75% root-FS usage, unremovable paths, unreadable lru.json) go to the journal at real warning priority, matching docker-prune:
+Disk hygiene prunes stale VS Code server builds (keeps 2 newest + any running), old extension versions, VSIX cache >14d, npm cache + `_npx` >30d, uv/pre-commit caches, and orphaned worktree dirs (`.claude/worktrees/*`, `.worktrees/*` not in `git worktree list`, aged >30min). Never touches Docker, Postgres, or registered worktrees. Dry-run: `infra/disk-hygiene.sh --dry-run`. Sandbox test rig: `bash tests/shell/disk-hygiene-test.sh`. Warnings (≥75% root-FS usage, unremovable paths, unreadable lru.json) go to the journal at real warning priority, matching docker-prune:
 
 ```bash
 journalctl -u disk-hygiene -p info      # full run log

--- a/infra/disk-hygiene.service
+++ b/infra/disk-hygiene.service
@@ -4,6 +4,8 @@ Description=Prune stale VS Code server builds, dev caches, orphaned worktrees
 [Service]
 Type=oneshot
 User=exedev
+Nice=10
+IOSchedulingClass=idle
 Environment=HOME=/home/exedev
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 ExecStart=/home/exedev/address-validator/infra/disk-hygiene.sh

--- a/infra/disk-hygiene.sh
+++ b/infra/disk-hygiene.sh
@@ -111,7 +111,7 @@ if command -v npm >/dev/null 2>&1; then
   if ((DRY_RUN)); then
     log "would run: npm cache clean --force"
   else
-    npm cache clean --force 2>/dev/null || log "npm cache clean failed (non-fatal)"
+    npm cache clean --force 2>/dev/null || warn "npm cache clean failed (non-fatal)"
   fi
 fi
 if [[ -d "${HOME}/.npm/_npx" ]]; then
@@ -125,7 +125,7 @@ if command -v uv >/dev/null 2>&1; then
   if ((DRY_RUN)); then
     log "would run: uv cache prune"
   else
-    uv cache prune 2>/dev/null || log "uv cache prune failed (non-fatal)"
+    uv cache prune 2>/dev/null || warn "uv cache prune failed (non-fatal)"
   fi
 fi
 
@@ -134,7 +134,7 @@ if [[ -x "${REPO}/.venv/bin/pre-commit" ]]; then
   if ((DRY_RUN)); then
     log "would run: pre-commit gc"
   else
-    "${REPO}/.venv/bin/pre-commit" gc 2>/dev/null || log "pre-commit gc failed (non-fatal)"
+    "${REPO}/.venv/bin/pre-commit" gc 2>/dev/null || warn "pre-commit gc failed (non-fatal)"
   fi
 fi
 
@@ -142,7 +142,7 @@ fi
 if ((!DRY_RUN)); then
   git -C "$REPO" worktree prune
 fi
-registered=$(git -C "$REPO" worktree list --porcelain | awk '/^worktree /{print $2}')
+registered=$(git -C "$REPO" worktree list --porcelain | sed -n 's/^worktree //p')
 for base in "${REPO}/.claude/worktrees" "${REPO}/.worktrees"; do
   [[ -d "$base" ]] || continue
   for dir in "$base"/*/; do

--- a/tests/shell/disk-hygiene-test.sh
+++ b/tests/shell/disk-hygiene-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Self-checking sandbox tests for infra/disk-hygiene.sh.
+#
+# Runs the hygiene script against a throwaway $HOME and a throwaway git repo,
+# so nothing outside the sandbox is read or deleted (npm/uv resolve their
+# caches from $HOME; the worktree sweep resolves the repo from the script's
+# own location). warn() calls do emit real journal lines tagged disk-hygiene.
+#
+# Usage: bash tests/shell/disk-hygiene-test.sh
+
+set -euo pipefail
+
+FAILS=0
+check() {
+  local desc=$1
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+cleanup() {
+  chmod -R u+rwx "$sandbox" 2>/dev/null || true
+  rm -rf "$sandbox"
+}
+trap cleanup EXIT
+
+# Sandbox repo: the script derives REPO from its own location, so a copy
+# inside a scratch repo keeps `git worktree prune` and the orphan sweep
+# away from the real repo
+mkdir -p "$sandbox/repo/infra"
+cp "$repo_root/infra/disk-hygiene.sh" "$sandbox/repo/infra/"
+git -C "$sandbox/repo" init -q
+git -C "$sandbox/repo" -c user.name=test -c user.email=test@test commit -q --allow-empty -m init
+SCRIPT="$sandbox/repo/infra/disk-hygiene.sh"
+OUT="$sandbox/out.log"
+
+fake="$sandbox/home"
+servers="$fake/.vscode-server/cli/servers"
+ext="$fake/.vscode-server/extensions"
+vsix="$fake/.vscode-server/data/CachedExtensionVSIXs"
+mkdir -p "$servers"/Stable-dhtest-{keep1,keep2,old} "$ext"/dhtest.ext-1.0.{9,10} "$vsix" "$fake/.npm/_npx"/{fresh,stale}
+echo '["Stable-dhtest-keep1","Stable-dhtest-keep2"]' >"$servers/lru.json"
+touch -d "2 days ago" "$ext/dhtest.ext-1.0.10"      # newer version, older mtime
+touch "$vsix/fresh.vsix"
+touch -d "20 days ago" "$vsix/stale.vsix"
+touch -d "40 days ago" "$fake/.npm/_npx/stale"
+
+# Worktree fixtures: one registered, one young orphan, one old orphan
+git -C "$sandbox/repo" worktree add -q .worktrees/registered-wt -b wt-branch
+mkdir -p "$sandbox/repo/.worktrees/orphan-young" "$sandbox/repo/.worktrees/orphan-old"
+touch -d "2 hours ago" "$sandbox/repo/.worktrees/orphan-old"
+
+# du/rm fail-open fixture: unreadable subdir inside a doomed server build
+mkdir -p "$servers/Stable-dhtest-old/locked"
+touch "$servers/Stable-dhtest-old/locked/f"
+chmod 000 "$servers/Stable-dhtest-old/locked"
+
+# --- argument rejection ---
+rc=0
+HOME=$fake "$SCRIPT" --bogus >/dev/null 2>&1 || rc=$?
+check "unknown argument rejected with exit 2" test "$rc" -eq 2
+
+# --- real run against the sandbox ---
+rc=0
+HOME=$fake "$SCRIPT" >"$OUT" 2>&1 || rc=$?
+
+check "run completes despite unremovable path" test "$rc" -eq 0
+check "unremovable path warned, not fatal" /bin/grep -q "WARNING: could not fully remove" "$OUT"
+check "kept lru server 1 survives" test -d "$servers/Stable-dhtest-keep1"
+check "kept lru server 2 survives" test -d "$servers/Stable-dhtest-keep2"
+check "higher extension version survives despite older mtime" test -d "$ext/dhtest.ext-1.0.10"
+check "lower extension version removed" test ! -d "$ext/dhtest.ext-1.0.9"
+check "fresh VSIX survives" test -e "$vsix/fresh.vsix"
+check "stale VSIX removed" test ! -e "$vsix/stale.vsix"
+check "fresh _npx sandbox survives" test -d "$fake/.npm/_npx/fresh"
+check "stale _npx sandbox removed" test ! -d "$fake/.npm/_npx/stale"
+check "registered worktree survives" test -d "$sandbox/repo/.worktrees/registered-wt"
+check "young orphan worktree survives (in-flight window)" test -d "$sandbox/repo/.worktrees/orphan-young"
+check "old orphan worktree removed" test ! -d "$sandbox/repo/.worktrees/orphan-old"
+
+# --- corrupt lru.json skips server prune instead of deleting ---
+echo 'not json' >"$servers/lru.json"
+rc=0
+HOME=$fake "$SCRIPT" >"$OUT" 2>&1 || rc=$?
+check "corrupt lru.json run exits 0" test "$rc" -eq 0
+check "corrupt lru.json warns and skips" /bin/grep -q "skipping server-build prune" "$OUT"
+check "servers untouched under corrupt lru.json" test -d "$servers/Stable-dhtest-keep1"
+
+# --- empty lru.json also skips ---
+echo '[]' >"$servers/lru.json"
+HOME=$fake "$SCRIPT" >"$OUT" 2>&1 || true
+check "empty lru.json warns and skips" /bin/grep -q "skipping server-build prune" "$OUT"
+
+echo
+if ((FAILS > 0)); then
+  echo "$FAILS assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
CR round 2 findings 10-13 (directives: 10 fix, 11 warn, 12 add, 13 commit).

- Registered-worktree list parsed with sed 's/^worktree //p' — awk $2 truncated at spaces, inverting the orphan-protection for unusual paths
- npm/uv/pre-commit non-fatal failures emit at journal warning priority
- Service unit: Nice=10, IOSchedulingClass=idle
- Self-checking sandbox test rig committed (tests/shell/disk-hygiene-test.sh, 18 assertions, fully isolated fake HOME + scratch repo); shellcheck hook now covers tests/shell/

Test run: 18/18 PASS. shellcheck: passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)