### PR TITLE
#155 [docs]: USPS launch slipped to Aug 1 — canary window shifted

### DIFF
--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -56,24 +56,26 @@ When a provider is rate-limited (HTTP 429 after all retries), the next provider 
 - Register at https://developer.usps.com.
 - `USPSProvider` and its `_http_client` are module-level singletons in `factory.py` — reset in tests.
 
-### Enhanced Addresses API switch — gap runbook (July 12, 2026)
+### Enhanced Addresses API switch — gap runbook (August 1, 2026)
 
-Effective 2026-07-12 USPS requires a signed Addressing API License Agreement +
-Order Form + Enterprise Payment System (EPS) account, with consumption
-tier-based fees. **Cutover: 2026-07-12 10:00 CT (15:00 UTC). License executed
-2026-07-06.** Design doc: `docs/plans/2026-07-02-usps-enhanced-api-switch-design.md`.
+Effective 2026-08-01 (slipped from 2026-07-12; announced 2026-07-09) USPS
+requires a signed Addressing API License Agreement + Order Form + Enterprise
+Payment System (EPS) account, with consumption tier-based fees. **Launch time
+unannounced; canary assumes the prior 10:00 CT (15:00 UTC) carries over.
+License executed 2026-07-06.** Design doc: `docs/plans/2026-07-02-usps-enhanced-api-switch-design.md`.
 
 **Enhanced Addresses spec is published** (v3.3.1, vendored at
 `docs/usps-enhanced-addresses-v3r2.yaml`): same servers and `/address` path,
 `DPVConfirmation`/`vacant` retained — current provider works unchanged. New
 `additionalInfo` indicators are recon targets (GH #122).
 
-**Canary:** `scripts/usps_canary.sh` runs daily 16:23 UTC July 10–20 via
-crontab (`23 16 10-20 7 *`) — after the 15:00 UTC cutover on switch day, so
-the July 12 run probes the post-cutover API. Probes OAuth, a live `/address` call (cache
+**Canary:** `scripts/usps_canary.sh` runs daily 16:23 UTC July 30 – August 9
+via crontab (`23 16 30-31 7 *` + `23 16 1-9 8 *`) — after the assumed
+15:00 UTC cutover on switch day, so the August 1 run probes the post-cutover
+API. Probes OAuth, a live `/address` call (cache
 bypassed, no DB writes), both vendored spec checksums, and portal spec links;
-comments on GH #155 on anomaly (always on July 12). Remove the crontab entry
-after July 20.
+comments on GH #155 on anomaly (always on August 1). Remove both crontab
+entries after August 9.
 
 If USPS starts rejecting our OAuth credentials (401/403 → `ProviderBadRequestError`,
 logged as operator-action-required) before the license is executed:

--- a/docs/plans/2026-07-02-usps-enhanced-api-switch-design.md
+++ b/docs/plans/2026-07-02-usps-enhanced-api-switch-design.md
@@ -118,3 +118,11 @@ Two design assumptions were overtaken by events the same day:
   survive to the window. Script exits non-zero on anomaly and comments on
   GH #155.
 - `USPS_API_BASE` shipped in PR #156.
+
+## Addendum 2 (2026-07-09, timeline slip)
+
+USPS moved the launch from 2026-07-12 to **2026-08-01** (time unannounced;
+canary assumes the prior 10:00 CT / 15:00 UTC carries over). License agreement
+executed 2026-07-06. Canary window shifted to **Jul 30 – Aug 9**, crontab
+`23 16 30-31 7 *` + `23 16 1-9 8 *`; script switch-day literal now `08-01`.
+Remove both crontab entries after 2026-08-09.

--- a/scripts/usps_canary.sh
+++ b/scripts/usps_canary.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # USPS Enhanced Addresses API switch canary — GH #155.
 #
-# Daily crontab probe for the 2026-07-12 licensing switch (window Jul 10-20;
-# cutover 2026-07-12 15:00 UTC — 16:23 runs land post-cutover on switch day):
-#   23 16 10-20 7 * /home/exedev/address-validator/scripts/usps_canary.sh
+# Daily crontab probe for the 2026-08-01 licensing switch (window Jul 30 -
+# Aug 9; launch time unannounced — 16:23 UTC runs land post-cutover if the
+# prior 10:00 CT (15:00 UTC) time carries over):
+#   23 16 30-31 7 * /home/exedev/address-validator/scripts/usps_canary.sh
+#   23 16 1-9 8 * /home/exedev/address-validator/scripts/usps_canary.sh
 #
 # Probes (all bypass the service cache; nothing is written to the prod DB):
 #   1. OAuth2 token endpoint with production creds
@@ -13,7 +15,7 @@
 #   5. Developer-portal pages for spec files beyond the two known ones
 #
 # Logs to scratch/usps-canary.log (gitignored). Comments on GH #155 when any
-# probe fails or drifts — and unconditionally on July 12 (switch day).
+# probe fails or drifts — and unconditionally on August 1 (switch day).
 # Exits 1 when any probe recorded an anomaly, 0 otherwise.
 set -u
 
@@ -111,7 +113,7 @@ else
 fi
 
 # Report — on any anomaly, and unconditionally on switch day
-if [ ${#ANOMALIES[@]} -gt 0 ] || [ "$(date -u +%m-%d)" = "07-12" ]; then
+if [ ${#ANOMALIES[@]} -gt 0 ] || [ "$(date -u +%m-%d)" = "08-01" ]; then
   GH_TOKEN=$(getvar GH_TOKEN "$REPO/.env")
   export GH_TOKEN
   {


### PR DESCRIPTION
USPS moved the Enhanced Addresses launch from 2026-07-12 to **2026-08-01** (announced 2026-07-09; time TBC — assuming prior 10:00 CT / 15:00 UTC).

- Canary script: switch-day literal `07-12` → `08-01`; header documents the new two-line crontab
- Crontab on the VM (applied separately): `23 16 30-31 7 *` + `23 16 1-9 8 *` (Jul 30 – Aug 9, 16:23 UTC)
- Runbook + design-doc addendum updated; crontab removal deadline now Aug 9

Part of #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)