### PR TITLE
#162 [docs]: CR round 4 — complete pre-commit hook inventory in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ uv run ruff format .            # format
 bash tests/shell/disk-hygiene-test.sh    # infra shell-script sandbox tests
 ```
 
-Coverage floor: **80%** line + branch. Baseline ~93% — don't regress. Pre-commit hooks must pass before any commit (ruff, plus ESLint + Prettier when admin JS is touched).
+Coverage floor: **80%** line + branch. Baseline ~93% — don't regress. Pre-commit hooks must pass before any commit (ruff; ESLint + Prettier when admin JS is touched; shellcheck + sandbox rig when infra/test shell scripts are touched).
 
 **NEVER** source `/etc/address-validator/.env` before running tests. That file sets `VALIDATION_CACHE_DSN` to the production database; the audit middleware writes real rows on every `TestClient` request. `tests/conftest.py` sets `VALIDATION_CACHE_DSN` via `os.environ.setdefault` so no shell prep is needed for `uv run pytest`. See `.env.test` for standalone-script use.
 


### PR DESCRIPTION
CR round 4 finding 17: AGENTS.md hook parenthetical now lists shellcheck + the disk-hygiene sandbox rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)