### PR TITLE
#170 [fix]: collapse duplicate '#' unit phrase restated by named designator

### DIFF
--- a/src/address_validator/core/pipeline_version.py
+++ b/src/address_validator/core/pipeline_version.py
@@ -32,7 +32,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Bump on any code change that alters parse/standardize output. See module docstring.
-PIPELINE_CODE_VERSION = 1
+PIPELINE_CODE_VERSION = 2
 
 # Fingerprint of the active custom model; None → bundled usaddress model.
 _model_fingerprint: str | None = None

--- a/src/address_validator/services/parse_recovery.py
+++ b/src/address_validator/services/parse_recovery.py
@@ -62,6 +62,9 @@ _UNIT_SLOT_PAIRS = (
 # Keys that represent unit-type fields (primary or sub-unit type).
 _UNIT_TYPE_KEYS: frozenset[str] = frozenset({"sub_premise_type", "dependent_sub_premise_type"})
 
+# type-key → paired identifier-key (derived from the slot pairs).
+_UNIT_TYPE_TO_ID: dict[str, str] = dict(_UNIT_SLOT_PAIRS)
+
 # Keys that signal the end of the street portion of an address.
 _POST_STREET_KEYS: frozenset[str] = frozenset({"locality", "administrative_area", "postcode"})
 
@@ -168,7 +171,15 @@ def collect_ambiguous_components(
         # canonical UNIT_MAP designators (GH #129: e.g. "SMP").  We still
         # require the token to *look* like a designator (alphabetic) so a
         # mislabelled number or fragment is not promoted to a slot.
-        if key in _UNIT_TYPE_KEYS and key in component_values:
+        #
+        # The same routing applies when the slot's *identifier* is already
+        # occupied even though the type is not (GH #170: "#1, UNIT 1" — the
+        # '#' phrase fills sub_premise_number before the first OccupancyType
+        # arrives).  Pairing this type with the earlier identifiers would fuse
+        # two distinct unit phrases into one.
+        if key in _UNIT_TYPE_KEYS and (
+            key in component_values or component_values.get(_UNIT_TYPE_TO_ID[key])
+        ):
             cleaned_unit_token = token.upper().replace(".", "").strip(",;")
             known_designator = cleaned_unit_token in UNIT_MAP
             if known_designator or cleaned_unit_token.isalpha():
@@ -363,6 +374,15 @@ def _normalize_unit_value(value: str) -> str:
     return value.upper().replace(".", "").strip(",;. ")
 
 
+def _normalize_unit_identifier(value: str) -> str:
+    """Normalize an identifier for duplicate comparison, dropping any '#'.
+
+    A bare ``"# 1"`` phrase and a named ``"UNIT 1"`` carry the same
+    identifier; the pound sign is a designator stand-in, not identifier text.
+    """
+    return _normalize_unit_value(value.replace("#", ""))
+
+
 def _dedupe_secondary_units(components: dict[str, str]) -> None:
     """Collapse an identical-duplicate secondary unit into a single slot.
 
@@ -375,9 +395,27 @@ def _dedupe_secondary_units(components: dict[str, str]) -> None:
     When the dependent unit's normalized (type, id) equals the primary's, drop
     the dependent slot so only one unit survives.  Distinct second units
     (``"STE J, SMP 2"``) differ in type or id and are left untouched.
+
+    A second duplicate shape (GH #170): a bare ``'#'`` phrase restated by a
+    named designator (``"#1, UNIT 1"``).  The '#' identifiers land in the
+    primary slot with no type; the named unit routes to the dependent slot.
+    When the identifiers match, the named designator wins the primary slot and
+    the '#' phrase is dropped.  Distinct pairs (``"#108 STE B"``) differ in
+    identifier and keep both slots.
     """
     primary_type = components.get("sub_premise_type")
     dep_type = components.get("dependent_sub_premise_type")
+
+    primary_unnamed = not primary_type or _normalize_unit_value(primary_type) == "#"
+    if primary_unnamed and dep_type:
+        primary_id = _normalize_unit_identifier(components.get("sub_premise_number", ""))
+        dep_id = _normalize_unit_identifier(components.get("dependent_sub_premise_number", ""))
+        if primary_id and primary_id == dep_id:
+            components["sub_premise_type"] = dep_type
+            components["sub_premise_number"] = components["dependent_sub_premise_number"]
+            components.pop("dependent_sub_premise_type", None)
+            components.pop("dependent_sub_premise_number", None)
+            return
 
     # Nothing to fold when either slot lacks a type.
     if not primary_type or not dep_type:

--- a/tests/unit/services/test_parser.py
+++ b/tests/unit/services/test_parser.py
@@ -402,6 +402,61 @@ class TestRepeatedLabelFallback:
         assert not vals.get("dependent_sub_premise_number")
         assert "SPANAWAY" in vals.get("locality", "")
 
+    @pytest.mark.parametrize(
+        ("raw", "designator", "identifier", "city"),
+        [
+            (
+                "19315 BOTHELL EVERETT HWY #1, UNIT 1 BOTHELL, WA 98012",
+                "UNIT",
+                "1",
+                "BOTHELL",
+            ),
+            (
+                "2615 OLD HIGHWAY 99 S RD #A, UNIT A MOUNT VERNON, WA 98273-8273",
+                "UNIT",
+                "A",
+                "MOUNT VERNON",
+            ),
+            (
+                "11525 E DAY MT SPOKANE RD #B, STE B MEAD, WA 99021",
+                "STE",
+                "B",
+                "MEAD",
+            ),
+        ],
+    )
+    async def test_duplicate_hash_unit_collapsed_into_named_unit(
+        self, raw: str, designator: str, identifier: str, city: str
+    ) -> None:
+        """GH-170: '#1, UNIT 1' states the same unit twice (data-entry idiom).
+
+        usaddress tags '#' and '1,' as OccupancyIdentifier before the first
+        OccupancyType arrives, so the identifiers must not concatenate into
+        'UNIT # 1, 1' — the named designator wins and the '#' phrase is
+        dropped as a duplicate.
+        """
+        outcome = await parse_address(raw)
+        vals = outcome.response.components.values
+        assert vals.get("sub_premise_type") == designator
+        assert vals.get("sub_premise_number") == identifier
+        assert not vals.get("dependent_sub_premise_type")
+        assert not vals.get("dependent_sub_premise_number")
+        assert city in vals.get("locality", "")
+
+    async def test_distinct_hash_unit_and_named_unit_both_kept(self) -> None:
+        """GH-170 guard: '#108 STE B' is two distinct units — no collapse.
+
+        The bare '#' phrase keeps the primary slot; the named designator is
+        routed to dependent_sub_premise and neither folds into the other.
+        """
+        outcome = await parse_address("5041 RAINIER AVE S #108 STE B, SEATTLE, WA 98118-1946")
+        vals = outcome.response.components.values
+        assert "108" in vals.get("sub_premise_number", "")
+        assert "STE" not in vals.get("sub_premise_number", "")
+        assert vals.get("dependent_sub_premise_type") == "STE"
+        assert vals.get("dependent_sub_premise_number") == "B"
+        assert "SEATTLE" in vals.get("locality", "")
+
 
 # ---------------------------------------------------------------------------
 # ZIP normalisation

--- a/tests/unit/test_pipeline_output_pin.py
+++ b/tests/unit/test_pipeline_output_pin.py
@@ -32,8 +32,8 @@ from address_validator.services.standardizer import standardize
 # Pins — update together with PIPELINE_CODE_VERSION (see module docstring)
 # ---------------------------------------------------------------------------
 
-_PINNED_CODE_VERSION = 1
-_PINNED_CORPUS_HASH = "446138393213f9a9a0b94c8c139ef81e77a2314fdc7b56f5ec6044e28d1e1523"
+_PINNED_CODE_VERSION = 2
+_PINNED_CORPUS_HASH = "48ce9554c1b6774dcb41961293817576bbd0407f4a96bec0d55af9a6ad78dd20"
 
 # Fixed corpus — exercises the pipeline surfaces most likely to change output:
 # cleanup regexes, directional/type abbreviation, secondary units, PO Box / rural
@@ -57,6 +57,8 @@ _CORPUS = [
     "456 Oak Ln (rear entrance) Boise ID 83702",
     "The Grove, Los Angeles CA",
     "1/2 421 Elm St Tampa FL 33602",
+    "19315 BOTHELL EVERETT HWY #1, UNIT 1 BOTHELL, WA 98012",
+    "5041 RAINIER AVE S #108 STE B, SEATTLE, WA 98118-1946",
 ]
 
 


### PR DESCRIPTION
Fixes #170.

`19315 BOTHELL EVERETT HWY #1, UNIT 1 BOTHELL, WA 98012` standardized to line 2 `UNIT # 1, 1` — the `#` phrase fills `sub_premise_number` before the first `OccupancyType` token arrives, so the RepeatedLabelError routing paired `UNIT` with the foreign identifiers and concatenated all three tokens.

## Changes

- `collect_ambiguous_components`: route a unit-type token to the next free slot when its slot's **identifier** is already occupied, not only when the type key repeats.
- `_dedupe_secondary_units`: when the primary slot is a bare `#` phrase (identifier, no type) and the dependent slot's normalized identifier matches, the named designator wins the primary slot and the `#` duplicate is dropped. Distinct pairs (`#108 STE B`) keep both slots.
- `PIPELINE_CODE_VERSION` 1 → 2 + golden-corpus re-pin (2 corpus entries appended).

## Result

- `…HWY #1, UNIT 1 BOTHELL…` → `UNIT 1` (was `UNIT # 1, 1`)
- `…RD #A, UNIT A MOUNT VERNON…` → `UNIT A`
- `…RD #B, STE B MEAD…` → `STE B`
- `…AVE S #108 STE B…` → both units kept (no false collapse)

## Verification

- 4 new parser tests (3 collapse cases + 1 distinct-units guard), TDD red→green
- Full suite: 1016 passed, coverage 94.99%; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)