### PR TITLE
#170 [fix]: CR round 1 — catalogued warning on duplicate-unit collapse

### DIFF
--- a/docs/WARNINGS.md
+++ b/docs/WARNINGS.md
@@ -31,6 +31,7 @@ This catalogue covers the **response `warnings` channel only**. Operational
 | `Unit designator recovered from mis-tagged field: '{designator}'` | `services/parser.py` | A unit designator was found in a mis-tagged field and reassigned; `{designator}` is the recovered token. |
 | `Unit identifier fragment recovered from city field` | `services/parser.py` | A unit identifier fragment was found in the city/locality field and moved to the unit. |
 | `Unrecognized unit designator preserved: '{designator}'` | `services/parser.py` | A unit-type token not in `UNIT_MAP` was preserved as-is (GH #129); `{designator}` is the token. |
+| `Duplicate secondary unit collapsed into '{designator} {identifier}'` | `services/parse_recovery.py` | A bare `#` unit phrase restated the same unit as a named designator (`#1, UNIT 1` — GH #170); the `#` phrase was dropped and the named unit kept. |
 | `Address has no parseable street line; passing raw input to provider` | `services/validation/pipeline.py` | No street line could be parsed; the raw input is forwarded to the validation provider. |
 | `Unrecognized province/territory: '{region}'` | `services/standardizer/ca.py` | A Canadian province/territory value was not recognized and is passed through unchanged; `{region}` is the value. |
 | `Provider inferred one or more address components not present in input` | `services/validation/google_provider.py` | The Google provider inferred components absent from the input. |

--- a/src/address_validator/core/pipeline_version.py
+++ b/src/address_validator/core/pipeline_version.py
@@ -32,7 +32,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Bump on any code change that alters parse/standardize output. See module docstring.
-PIPELINE_CODE_VERSION = 2
+PIPELINE_CODE_VERSION = 3
 
 # Fingerprint of the active custom model; None → bundled usaddress model.
 _model_fingerprint: str | None = None

--- a/src/address_validator/core/warnings.py
+++ b/src/address_validator/core/warnings.py
@@ -34,6 +34,7 @@ PARENTHESIZED_REMOVED = "Parenthesized text removed: '{text}'"
 REPEATED_NUMBERS_RANGE = "Ambiguous parse: repeated address numbers joined as range '{range}'"
 UNIT_RECOVERED_FROM_FIELD = "Unit designator recovered from mis-tagged field: '{designator}'"
 UNRECOGNIZED_UNIT_DESIGNATOR = "Unrecognized unit designator preserved: '{designator}'"
+DUPLICATE_UNIT_COLLAPSED = "Duplicate secondary unit collapsed into '{designator} {identifier}'"
 UNRECOGNIZED_REGION = "Unrecognized province/territory: '{region}'"
 
 # Authoritative list of every catalogued response warning. The drift test
@@ -46,6 +47,7 @@ CATALOGUE: tuple[str, ...] = (
     UNIT_RECOVERED_FROM_FIELD,
     UNIT_FRAGMENT_FROM_CITY,
     UNRECOGNIZED_UNIT_DESIGNATOR,
+    DUPLICATE_UNIT_COLLAPSED,
     NO_PARSEABLE_STREET,
     UNRECOGNIZED_REGION,
     PROVIDER_INFERRED,

--- a/src/address_validator/services/parse_recovery.py
+++ b/src/address_validator/services/parse_recovery.py
@@ -383,7 +383,10 @@ def _normalize_unit_identifier(value: str) -> str:
     return _normalize_unit_value(value.replace("#", ""))
 
 
-def _dedupe_secondary_units(components: dict[str, str]) -> None:
+def _dedupe_secondary_units(
+    components: dict[str, str],
+    warnings: list[str] | None = None,
+) -> None:
     """Collapse an identical-duplicate secondary unit into a single slot.
 
     The RLE routing in :func:`collect_ambiguous_components` slots a repeated
@@ -411,10 +414,19 @@ def _dedupe_secondary_units(components: dict[str, str]) -> None:
         primary_id = _normalize_unit_identifier(components.get("sub_premise_number", ""))
         dep_id = _normalize_unit_identifier(components.get("dependent_sub_premise_number", ""))
         if primary_id and primary_id == dep_id:
+            kept_id = components["dependent_sub_premise_number"]
             components["sub_premise_type"] = dep_type
-            components["sub_premise_number"] = components["dependent_sub_premise_number"]
+            components["sub_premise_number"] = kept_id
             components.pop("dependent_sub_premise_type", None)
             components.pop("dependent_sub_premise_number", None)
+            # Input content is being dropped — signal it, especially on the
+            # clean parse path where no "Ambiguous parse" warning exists.
+            if warnings is not None:
+                warnings.append(
+                    warning_catalogue.DUPLICATE_UNIT_COLLAPSED.format(
+                        designator=dep_type, identifier=kept_id
+                    )
+                )
             return
 
     # Nothing to fold when either slot lacks a type.
@@ -446,4 +458,4 @@ def recover_components(
     """
     _recover_unit_from_city(component_values, warnings)
     _recover_identifier_fragment_from_city(component_values, warnings)
-    _dedupe_secondary_units(component_values)
+    _dedupe_secondary_units(component_values, warnings)

--- a/tests/unit/services/test_parser.py
+++ b/tests/unit/services/test_parser.py
@@ -442,6 +442,23 @@ class TestRepeatedLabelFallback:
         assert not vals.get("dependent_sub_premise_type")
         assert not vals.get("dependent_sub_premise_number")
         assert city in vals.get("locality", "")
+        # The dropped '#' phrase must be signalled, not silent.
+        assert any("Duplicate secondary unit collapsed" in w for w in outcome.response.warnings)
+
+    async def test_duplicate_unit_collapse_warns_on_clean_parse_path(self) -> None:
+        """GH-170 CR: the collapse heuristic also fires on a clean (non-RLE)
+        parse — '#2 BLDG 2' tags cleanly with the '#' phrase in the primary
+        slot and BLDG in the dependent slot.  Dropping the '#' phrase there
+        must emit the catalogued warning; a clean parse must never silently
+        discard input content.
+        """
+        outcome = await parse_address("123 MAIN ST #2 BLDG 2 SEATTLE, WA 98101")
+        result = outcome.response
+        assert result.type == "Street Address"
+        vals = result.components.values
+        assert vals.get("sub_premise_type") == "BLDG"
+        assert vals.get("sub_premise_number") == "2"
+        assert any("Duplicate secondary unit collapsed" in w for w in result.warnings)
 
     async def test_distinct_hash_unit_and_named_unit_both_kept(self) -> None:
         """GH-170 guard: '#108 STE B' is two distinct units — no collapse.

--- a/tests/unit/test_pipeline_output_pin.py
+++ b/tests/unit/test_pipeline_output_pin.py
@@ -32,8 +32,8 @@ from address_validator.services.standardizer import standardize
 # Pins — update together with PIPELINE_CODE_VERSION (see module docstring)
 # ---------------------------------------------------------------------------
 
-_PINNED_CODE_VERSION = 2
-_PINNED_CORPUS_HASH = "48ce9554c1b6774dcb41961293817576bbd0407f4a96bec0d55af9a6ad78dd20"
+_PINNED_CODE_VERSION = 3
+_PINNED_CORPUS_HASH = "0a10218354cb259e3b8db66b4e9e17e71e2d58ce612ce1cfa4849b7ff34f5b99"
 
 # Fixed corpus — exercises the pipeline surfaces most likely to change output:
 # cleanup regexes, directional/type abbreviation, secondary units, PO Box / rural


### PR DESCRIPTION
CR round 1 finding 1 for #170 (follow-up to #171).

The duplicate-unit collapse runs in `recover_components`, which both the RLE and the **clean** parse paths call — `123 MAIN ST #2 BLDG 2 SEATTLE, WA 98101` parses cleanly and dropped the `#2` phrase with zero warnings.

- New catalogued warning `DUPLICATE_UNIT_COLLAPSED` (`core/warnings.py` + `docs/WARNINGS.md`, drift test green)
- `_dedupe_secondary_units` takes the warnings list and emits on every collapse
- `PIPELINE_CODE_VERSION` 2 → 3 (warnings are part of pinned pipeline output); corpus re-pinned

Verification: full suite 1017 passed, coverage 95.03%; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)