### PR TITLE
#170 [fix]: CR round 1 — source-order line 2 for same-level unit pairs

### DIFF
--- a/src/address_validator/core/pipeline_version.py
+++ b/src/address_validator/core/pipeline_version.py
@@ -32,7 +32,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Bump on any code change that alters parse/standardize output. See module docstring.
-PIPELINE_CODE_VERSION = 3
+PIPELINE_CODE_VERSION = 4
 
 # Fingerprint of the active custom model; None → bundled usaddress model.
 _model_fingerprint: str | None = None

--- a/src/address_validator/services/standardizer/_lines.py
+++ b/src/address_validator/services/standardizer/_lines.py
@@ -61,6 +61,34 @@ def _get(components: dict[str, str], key: str) -> str:
     return val
 
 
+# Container designators (USPS Pub 28 secondary-unit hierarchy): these render
+# before the specific unit on line 2 regardless of source order.
+_CONTAINER_DESIGNATORS: frozenset[str] = frozenset({"BLDG", "FL"})
+
+
+def _sub_renders_first(components: dict[str, str], sub_type: str) -> bool:
+    """Decide line-2 slot order: does the dependent (sub) unit render first?
+
+    A container designator (BLDG/FL) always renders before the specific unit
+    per USPS Pub 28 (``"BLDG C STE 120"``).  For same-level pairs there is no
+    container relationship, so source order wins: *components* preserves
+    insertion order (token order for parsed input, JSON key order for direct
+    component input), and the slot whose keys appear first renders first
+    (GH #170: ``"#108 STE B"`` must not invert to ``"STE B # 108"``).
+    """
+    if sub_type in _CONTAINER_DESIGNATORS:
+        return True
+    keys = list(components)
+
+    def first_pos(*names: str) -> float:
+        positions = [keys.index(n) for n in names if n in keys]
+        return min(positions) if positions else float("inf")
+
+    sub_pos = first_pos("dependent_sub_premise_type", "dependent_sub_premise_number")
+    unit_pos = first_pos("sub_premise_type", "sub_premise_number")
+    return sub_pos < unit_pos
+
+
 # -- small helpers for assembling street fragments --------------------------
 
 
@@ -91,14 +119,19 @@ def _assemble_lines(
     unit_id: str,
     sub_type: str,
     sub_id: str,
+    *,
+    sub_first: bool = True,
 ) -> tuple[str, str, str]:
     """Build the three address lines from the standardised component dict.
 
     Returns ``(line1, line2, last_line)``:
 
     - **line1** — street number + street name, or PO box.
-    - **line2** — secondary-unit designators (USPS Pub 28: larger container
-      before more specific unit, e.g. ``"BLDG C STE 120"``).
+    - **line2** — secondary-unit designators.  *sub_first* controls slot
+      order: ``True`` (default) renders the dependent slot first — correct
+      when it holds a larger container (USPS Pub 28: ``"BLDG C STE 120"``);
+      callers pass :func:`_sub_renders_first` to preserve source order for
+      same-level unit pairs (GH #170).
     - **last_line** — city, state/region, and postal code in single-line
       format (``"CITY, ST ZIP"``).
     """
@@ -122,8 +155,13 @@ def _assemble_lines(
         line1 = ""
 
     # --- address line 2 ---
-    # Larger container (sub) before more specific unit (occupancy).
-    line2 = " ".join(p for p in (sub_type, sub_id, unit_type, unit_id) if p)
+    # Slot order per *sub_first* (container-first by default; source order
+    # for same-level pairs — see _sub_renders_first).
+    if sub_first:
+        ordered = (sub_type, sub_id, unit_type, unit_id)
+    else:
+        ordered = (unit_type, unit_id, sub_type, sub_id)
+    line2 = " ".join(p for p in ordered if p)
 
     # --- last line ---
     city = std.get("locality", "")

--- a/src/address_validator/services/standardizer/us.py
+++ b/src/address_validator/services/standardizer/us.py
@@ -11,6 +11,7 @@ from address_validator.services.standardizer._lines import (
     _get,
     _lookup,
     _std_zip,
+    _sub_renders_first,
 )
 from address_validator.usps_data.directionals import DIRECTIONAL_MAP
 from address_validator.usps_data.spec import USPS_PUB28_SPEC, USPS_PUB28_SPEC_VERSION
@@ -196,7 +197,14 @@ def standardize_us(
             std[gd_key] = v
 
     # --- assemble output lines ---
-    line1, line2, last_line = _assemble_lines(std, unit_type, unit_id, sub_type, sub_id)
+    line1, line2, last_line = _assemble_lines(
+        std,
+        unit_type,
+        unit_id,
+        sub_type,
+        sub_id,
+        sub_first=_sub_renders_first(components, sub_type),
+    )
 
     city = std.get("locality", "")
     state = std.get("administrative_area", "")

--- a/tests/unit/services/test_standardizer.py
+++ b/tests/unit/services/test_standardizer.py
@@ -154,6 +154,53 @@ class TestStandardize:
         result = standardize(comps)
         assert result.address_line_2 == "STE 300"
 
+    def test_same_level_units_render_in_source_order(self) -> None:
+        """GH-170 CR: '#108 STE B' — neither unit is a container, so line 2
+        preserves source order (insertion order of the component keys)
+        instead of forcing the dependent slot first.
+        """
+        comps = {
+            "premise_number": "5041",
+            "thoroughfare_name": "RAINIER",
+            "thoroughfare_trailing_type": "AVE",
+            "sub_premise_number": "# 108",
+            "dependent_sub_premise_type": "STE",
+            "dependent_sub_premise_number": "B",
+        }
+        result = standardize(comps)
+        assert result.address_line_2 == "# 108 STE B"
+
+    def test_same_level_units_dependent_first_in_source(self) -> None:
+        """Source order also wins when the dependent slot's keys were
+        inserted first — the pair renders dependent-then-primary."""
+        comps = {
+            "premise_number": "1210",
+            "thoroughfare_name": "WENATCHEE",
+            "thoroughfare_trailing_type": "AVE",
+            "dependent_sub_premise_type": "SMP",
+            "dependent_sub_premise_number": "2",
+            "sub_premise_type": "STE",
+            "sub_premise_number": "J",
+        }
+        result = standardize(comps)
+        assert result.address_line_2 == "SMP 2 STE J"
+
+    def test_container_unit_renders_first_regardless_of_source_order(self) -> None:
+        """USPS Pub 28: a container designator (BLDG/FL) in the dependent
+        slot renders before the specific unit even when it appeared later
+        in the source ('STE 120 BLDG C' → 'BLDG C STE 120')."""
+        comps = {
+            "premise_number": "1",
+            "thoroughfare_name": "CAMPUS",
+            "thoroughfare_trailing_type": "DR",
+            "sub_premise_type": "STE",
+            "sub_premise_number": "120",
+            "dependent_sub_premise_type": "BLDG",
+            "dependent_sub_premise_number": "C",
+        }
+        result = standardize(comps)
+        assert result.address_line_2 == "BLDG C STE 120"
+
     def test_building_name_recovery(self) -> None:
         """BLD C in premise_name should be recovered as BLDG C."""
         comps = {
@@ -204,6 +251,10 @@ class TestStandardize:
         '… STE J, SMP - 2 …' standardizes to a clean two-designator line2.
         The unknown 'SMP' designator is preserved; the comma the parser left
         on 'J,' is stripped during line assembly.
+
+        GH-170 CR: neither designator is a container, so line 2 follows
+        source order ('STE J' first) — the pre-GH-170 'SMP 2 STE J' was an
+        artifact of the fixed dependent-first assembly.
         """
         comps = {
             "premise_number": "1210",
@@ -219,7 +270,7 @@ class TestStandardize:
             "postcode": "98801",
         }
         result = standardize(comps)
-        assert result.address_line_2 == "SMP 2 STE J"
+        assert result.address_line_2 == "STE J SMP 2"
         assert "STE SMP" not in result.standardized
 
     def test_standardized_two_space_separator(self) -> None:

--- a/tests/unit/test_pipeline_output_pin.py
+++ b/tests/unit/test_pipeline_output_pin.py
@@ -32,8 +32,8 @@ from address_validator.services.standardizer import standardize
 # Pins — update together with PIPELINE_CODE_VERSION (see module docstring)
 # ---------------------------------------------------------------------------
 
-_PINNED_CODE_VERSION = 3
-_PINNED_CORPUS_HASH = "0a10218354cb259e3b8db66b4e9e17e71e2d58ce612ce1cfa4849b7ff34f5b99"
+_PINNED_CODE_VERSION = 4
+_PINNED_CORPUS_HASH = "ef9874185c970deafc6f0dba6e4d3b7f23b0b5df80337a8818194a198cc729d6"
 
 # Fixed corpus — exercises the pipeline surfaces most likely to change output:
 # cleanup regexes, directional/type abbreviation, secondary units, PO Box / rural


### PR DESCRIPTION
CR round 1 finding 4 for #170, option (b) as directed.

`_assemble_lines` rendered the dependent slot first unconditionally (USPS Pub 28 container-first premise), but slot assignment falls out of usaddress label choice and token arrival order, not containment — so same-level pairs inverted (`#108 STE B` → `STE B # 108`).

## Changes

- New `_sub_renders_first` (`standardizer/_lines.py`): a container designator (`BLDG`/`FL`) in the dependent slot always renders first per Pub 28; for same-level pairs, source order wins via component-dict insertion order (token order for parsed input, JSON key order for direct component input).
- `_assemble_lines` gains keyword-only `sub_first: bool = True`; CA path unchanged.
- GH-129 test expectation updated: `STE J, SMP - 2` → `STE J SMP 2` (old `SMP 2 STE J` was the same inversion artifact).
- `PIPELINE_CODE_VERSION` 3 → 4 + corpus re-pin.

## Result

- `#108 STE B` → `# 108 STE B` (source order)
- `STE 120 BLDG C` → `BLDG C STE 120` (container-first preserved)
- `BLDG 201 ROOM 104` → `BLDG 201 ROOM 104` (unchanged)

Verification: full suite 1020 passed, coverage 95.00%; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)