### PR TITLE
#170 [fix]: CR round 2 — warning normalization + docs polish

### DIFF
--- a/docs/WARNINGS.md
+++ b/docs/WARNINGS.md
@@ -26,11 +26,11 @@ This catalogue covers the **response `warnings` channel only**. Operational
 | Template | Emitting module | Trigger condition |
 |---|---|---|
 | `Parenthesized text removed: '{text}'` | `services/parser.py` | Parenthetical content stripped from the input before parsing; `{text}` is the removed inner text. |
-| `Ambiguous parse: repeated address numbers joined as range '{range}'` | `services/parser.py` | Two address numbers were detected and joined into a single range; `{range}` is the joined value. |
-| `Ambiguous parse: repeated labels detected; parse may be inaccurate.` | `services/parser.py` | usaddress emitted duplicate component labels; the parse may be unreliable. |
-| `Unit designator recovered from mis-tagged field: '{designator}'` | `services/parser.py` | A unit designator was found in a mis-tagged field and reassigned; `{designator}` is the recovered token. |
-| `Unit identifier fragment recovered from city field` | `services/parser.py` | A unit identifier fragment was found in the city/locality field and moved to the unit. |
-| `Unrecognized unit designator preserved: '{designator}'` | `services/parser.py` | A unit-type token not in `UNIT_MAP` was preserved as-is (GH #129); `{designator}` is the token. |
+| `Ambiguous parse: repeated address numbers joined as range '{range}'` | `services/parse_recovery.py` | Two address numbers were detected and joined into a single range; `{range}` is the joined value. |
+| `Ambiguous parse: repeated labels detected; parse may be inaccurate.` | `services/parse_recovery.py` | usaddress emitted duplicate component labels; the parse may be unreliable. |
+| `Unit designator recovered from mis-tagged field: '{designator}'` | `services/parse_recovery.py` | A unit designator was found in a mis-tagged field and reassigned; `{designator}` is the recovered token. |
+| `Unit identifier fragment recovered from city field` | `services/parse_recovery.py` | A unit identifier fragment was found in the city/locality field and moved to the unit. |
+| `Unrecognized unit designator preserved: '{designator}'` | `services/parse_recovery.py` | A unit-type token not in `UNIT_MAP` was preserved as-is (GH #129); `{designator}` is the token. |
 | `Duplicate secondary unit collapsed into '{designator} {identifier}'` | `services/parse_recovery.py` | A bare `#` unit phrase restated the same unit as a named designator (`#1, UNIT 1` — GH #170); the `#` phrase was dropped and the named unit kept. |
 | `Address has no parseable street line; passing raw input to provider` | `services/validation/pipeline.py` | No street line could be parsed; the raw input is forwarded to the validation provider. |
 | `Unrecognized province/territory: '{region}'` | `services/standardizer/ca.py` | A Canadian province/territory value was not recognized and is passed through unchanged; `{region}` is the value. |

--- a/src/address_validator/core/pipeline_version.py
+++ b/src/address_validator/core/pipeline_version.py
@@ -32,7 +32,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Bump on any code change that alters parse/standardize output. See module docstring.
-PIPELINE_CODE_VERSION = 4
+PIPELINE_CODE_VERSION = 5
 
 # Fingerprint of the active custom model; None → bundled usaddress model.
 _model_fingerprint: str | None = None

--- a/src/address_validator/services/parse_recovery.py
+++ b/src/address_validator/services/parse_recovery.py
@@ -421,10 +421,12 @@ def _dedupe_secondary_units(
             components.pop("dependent_sub_premise_number", None)
             # Input content is being dropped — signal it, especially on the
             # clean parse path where no "Ambiguous parse" warning exists.
+            # Tokens are normalized so warning text is casing-independent.
             if warnings is not None:
                 warnings.append(
                     warning_catalogue.DUPLICATE_UNIT_COLLAPSED.format(
-                        designator=dep_type, identifier=kept_id
+                        designator=_normalize_unit_value(dep_type),
+                        identifier=_normalize_unit_value(kept_id),
                     )
                 )
             return

--- a/src/address_validator/services/standardizer/_lines.py
+++ b/src/address_validator/services/standardizer/_lines.py
@@ -62,7 +62,10 @@ def _get(components: dict[str, str], key: str) -> str:
 
 
 # Container designators (USPS Pub 28 secondary-unit hierarchy): these render
-# before the specific unit on line 2 regardless of source order.
+# before the specific unit on line 2 regardless of source order.  Other
+# arguably-hierarchical Pub 28 designators (PIER, SLIP, STOP) were considered
+# and deliberately excluded — pairs like "PIER 5 SLIP 3" have no dominant
+# container convention, so they follow source order (GH #170 CR round 2).
 _CONTAINER_DESIGNATORS: frozenset[str] = frozenset({"BLDG", "FL"})
 
 

--- a/tests/unit/services/test_parser.py
+++ b/tests/unit/services/test_parser.py
@@ -460,6 +460,17 @@ class TestRepeatedLabelFallback:
         assert vals.get("sub_premise_number") == "2"
         assert any("Duplicate secondary unit collapsed" in w for w in result.warnings)
 
+    async def test_duplicate_unit_collapse_warning_is_normalized(self) -> None:
+        """GH-170 CR round 2: the collapse warning interpolates normalized
+        (uppercased, punctuation-stripped) tokens so the same address in any
+        casing yields identical warning text.
+        """
+        outcome = await parse_address("19315 bothell everett hwy #1, unit 1 bothell, wa 98012")
+        assert any(
+            "Duplicate secondary unit collapsed into 'UNIT 1'" in w
+            for w in outcome.response.warnings
+        ), outcome.response.warnings
+
     async def test_distinct_hash_unit_and_named_unit_both_kept(self) -> None:
         """GH-170 guard: '#108 STE B' is two distinct units — no collapse.
 

--- a/tests/unit/test_pipeline_output_pin.py
+++ b/tests/unit/test_pipeline_output_pin.py
@@ -32,7 +32,7 @@ from address_validator.services.standardizer import standardize
 # Pins — update together with PIPELINE_CODE_VERSION (see module docstring)
 # ---------------------------------------------------------------------------
 
-_PINNED_CODE_VERSION = 4
+_PINNED_CODE_VERSION = 5
 _PINNED_CORPUS_HASH = "ef9874185c970deafc6f0dba6e4d3b7f23b0b5df80337a8818194a198cc729d6"
 
 # Fixed corpus — exercises the pipeline surfaces most likely to change output:


### PR DESCRIPTION
CR round 2 directives for #170 (findings 5, 6, 7).

- **5:** `DUPLICATE_UNIT_COLLAPSED` now interpolates `_normalize_unit_value` tokens — lowercase input yields `'UNIT 1'`, not `'unit 1'`. `PIPELINE_CODE_VERSION` 4 → 5 (output changes for lowercase inputs; corpus hash unchanged since corpus entries are uppercase).
- **6:** `docs/WARNINGS.md` emitting-module column corrected for the five recovery warnings that moved to `services/parse_recovery.py` in GH #137.
- **7:** `_CONTAINER_DESIGNATORS` comment records the deliberate PIER/SLIP/STOP exclusion.

Verification: full suite 1021 passed, coverage 95.05%; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)