### PR TITLE
#170 [fix]: CR round 3 — warning uses UNIT_MAP abbreviation + corpus pin

### DIFF
--- a/src/address_validator/core/pipeline_version.py
+++ b/src/address_validator/core/pipeline_version.py
@@ -32,7 +32,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Bump on any code change that alters parse/standardize output. See module docstring.
-PIPELINE_CODE_VERSION = 5
+PIPELINE_CODE_VERSION = 6
 
 # Fingerprint of the active custom model; None → bundled usaddress model.
 _model_fingerprint: str | None = None

--- a/src/address_validator/services/parse_recovery.py
+++ b/src/address_validator/services/parse_recovery.py
@@ -421,11 +421,14 @@ def _dedupe_secondary_units(
             components.pop("dependent_sub_premise_number", None)
             # Input content is being dropped — signal it, especially on the
             # clean parse path where no "Ambiguous parse" warning exists.
-            # Tokens are normalized so warning text is casing-independent.
+            # Tokens are normalized, and the designator uses its UNIT_MAP
+            # abbreviation so the warning matches the standardized output
+            # ('suite' → 'STE').
             if warnings is not None:
+                designator = _normalize_unit_value(dep_type)
                 warnings.append(
                     warning_catalogue.DUPLICATE_UNIT_COLLAPSED.format(
-                        designator=_normalize_unit_value(dep_type),
+                        designator=UNIT_MAP.get(designator, designator),
                         identifier=_normalize_unit_value(kept_id),
                     )
                 )

--- a/tests/unit/services/test_parser.py
+++ b/tests/unit/services/test_parser.py
@@ -471,6 +471,17 @@ class TestRepeatedLabelFallback:
             for w in outcome.response.warnings
         ), outcome.response.warnings
 
+    async def test_duplicate_unit_collapse_warning_uses_usps_abbreviation(self) -> None:
+        """GH-170 CR round 3: the collapse warning names the designator the
+        same way the standardized output will — the UNIT_MAP abbreviation
+        ('suite' → 'STE'), not the raw input token.
+        """
+        outcome = await parse_address("19315 bothell everett hwy #1, suite 1 bothell, wa 98012")
+        assert any(
+            "Duplicate secondary unit collapsed into 'STE 1'" in w
+            for w in outcome.response.warnings
+        ), outcome.response.warnings
+
     async def test_distinct_hash_unit_and_named_unit_both_kept(self) -> None:
         """GH-170 guard: '#108 STE B' is two distinct units — no collapse.
 

--- a/tests/unit/test_pipeline_output_pin.py
+++ b/tests/unit/test_pipeline_output_pin.py
@@ -32,8 +32,8 @@ from address_validator.services.standardizer import standardize
 # Pins — update together with PIPELINE_CODE_VERSION (see module docstring)
 # ---------------------------------------------------------------------------
 
-_PINNED_CODE_VERSION = 5
-_PINNED_CORPUS_HASH = "ef9874185c970deafc6f0dba6e4d3b7f23b0b5df80337a8818194a198cc729d6"
+_PINNED_CODE_VERSION = 6
+_PINNED_CORPUS_HASH = "c0f8396780f7fa7a30d15c206d142505286401ab752dd0430532c19d3e57c4df"
 
 # Fixed corpus — exercises the pipeline surfaces most likely to change output:
 # cleanup regexes, directional/type abbreviation, secondary units, PO Box / rural
@@ -59,6 +59,7 @@ _CORPUS = [
     "1/2 421 Elm St Tampa FL 33602",
     "19315 BOTHELL EVERETT HWY #1, UNIT 1 BOTHELL, WA 98012",
     "5041 RAINIER AVE S #108 STE B, SEATTLE, WA 98118-1946",
+    "19315 bothell everett hwy #1, suite 1 bothell, wa 98012",
 ]
 
 


### PR DESCRIPTION
CR round 3 directives for #170 (findings 8, 9).

- **8:** `DUPLICATE_UNIT_COLLAPSED` designator now resolves through `UNIT_MAP`, so the warning names the unit exactly as the standardized output does (`suite 1` → `'STE 1'`, matching line 2's `STE 1`).
- **9:** golden corpus gains `19315 bothell everett hwy #1, suite 1 bothell, wa 98012` — pins warning normalization + abbreviation, which no prior (uppercase, pre-abbreviated) entry exercised.
- `PIPELINE_CODE_VERSION` 5 → 6, corpus re-pinned.

Verification: full suite 1022 passed, coverage 95.05%; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)