### PR TITLE
#155 [docs]: launch validated; canary window trimmed to Aug 2-6

### DIFF
--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -69,13 +69,12 @@ License executed 2026-07-06.** Design doc: `docs/plans/2026-07-02-usps-enhanced-
 `DPVConfirmation`/`vacant` retained — current provider works unchanged. New
 `additionalInfo` indicators are recon targets (GH #122).
 
-**Canary:** `scripts/usps_canary.sh` runs daily 16:23 UTC July 30 – August 9
-via crontab (`23 16 30-31 7 *` + `23 16 1-9 8 *`) — after the assumed
-15:00 UTC cutover on switch day, so the August 1 run probes the post-cutover
-API. Probes OAuth, a live `/address` call (cache
-bypassed, no DB writes), both vendored spec checksums, and portal spec links;
-comments on GH #155 on anomaly (always on August 1). Remove both crontab
-entries after August 9.
+**Canary:** `scripts/usps_canary.sh` — launch validated 2026-08-01 (Enhanced
+shape live on prod, zero changes needed); post-launch watch runs daily
+16:23 UTC August 2–6 via crontab (`23 16 2-6 8 *`). Probes OAuth, a live
+`/address` call (cache bypassed, no DB writes), both vendored spec checksums,
+and portal spec links; comments on GH #155 on anomaly. Remove the crontab
+entry after August 6.
 
 If USPS starts rejecting our OAuth credentials (401/403 → `ProviderBadRequestError`,
 logged as operator-action-required) before the license is executed:

--- a/scripts/usps_canary.sh
+++ b/scripts/usps_canary.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 # USPS Enhanced Addresses API switch canary — GH #155.
 #
-# Daily crontab probe for the 2026-08-01 licensing switch (window Jul 30 -
-# Aug 9; launch time unannounced — 16:23 UTC runs land post-cutover if the
-# prior 10:00 CT (15:00 UTC) time carries over):
-#   23 16 30-31 7 * /home/exedev/address-validator/scripts/usps_canary.sh
-#   23 16 1-9 8 * /home/exedev/address-validator/scripts/usps_canary.sh
+# Daily crontab probe for the 2026-08-01 licensing switch. Launch validated
+# 2026-08-01; post-launch watch window trimmed to Aug 2-6 per operator:
+#   23 16 2-6 8 * /home/exedev/address-validator/scripts/usps_canary.sh
 #
 # Probes (all bypass the service cache; nothing is written to the prod DB):
 #   1. OAuth2 token endpoint with production creds


### PR DESCRIPTION
Post-launch: production validated on the Enhanced API 2026-08-01 (zero changes needed). Operator trimmed the canary watch to 5 more days — crontab now a single `23 16 2-6 8 *` entry (applied on the VM); script header + runbook synced. Removal deadline now Aug 6.

Part of #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)