### PR TITLE
#187, #188: skills auto-refresh hook + SocratiCode artifact manifest repoint

### DIFF
--- a/.claude/hooks/skills-submodule-update.sh
+++ b/.claude/hooks/skills-submodule-update.sh
@@ -1,0 +1,1 @@
+../../skills-vendor/gregoryfoster-skills/skills/managing-skills/scripts/skills-submodule-update.sh

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,14 +9,13 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/socraticode-reminder.sh\""
           }
         ]
-      }
-    ],
-    "UserPromptSubmit": [
+      },
       {
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
-            "command": "LOCK=\"/tmp/av-submodule-update-$(date +%Y%m%d)\"; if [ ! -f \"$LOCK\" ]; then git submodule update --remote --merge vendor/gregoryfoster-skills vendor/obra-superpowers && touch \"$LOCK\" && if ! git diff --quiet HEAD vendor/gregoryfoster-skills vendor/obra-superpowers 2>/dev/null; then git add vendor/gregoryfoster-skills vendor/obra-superpowers && git commit -m 'chore: update skills submodules'; fi; fi"
+            "command": "bash .claude/hooks/skills-submodule-update.sh"
           }
         ]
       }

--- a/.skills/doctor.sh
+++ b/.skills/doctor.sh
@@ -15,6 +15,9 @@
 # `git submodule update --init --recursive` if any dangle, and prints a
 # clear actionable error if self-healing fails.
 #
+# Because the installed copy is a copy, it re-syncs itself from the vendored
+# source whenever that source is reachable — see sync_self below.
+#
 # Designed for use as a Phase 1 preflight in every reviewing-* / shipping-*
 # SKILL.md invocation. The doctor runs first so that the resolution loop that
 # follows sees a freshly healed symlink chain (issue #63):
@@ -28,7 +31,11 @@
 # Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--no-preflight] [--help]
 set -euo pipefail
 
-VERSION="2026-05-28-6"
+# Diagnostic stamp only — reported by --version so a bug report can name the
+# copy that produced it. Nothing branches on it: sync_self keeps the installed
+# copy equal to the vendored source, which makes drift transient and a
+# version-comparison mechanism unnecessary.
+VERSION="2026-08-04-2"
 
 CHECK_ONLY=0
 VERBOSE=0
@@ -50,6 +57,12 @@ present, runs 'git submodule update --init --recursive' and re-checks.
 Exits 0 silently when healthy. Exits non-zero with an actionable error
 when self-healing fails or is not possible (e.g. no .git directory).
 
+Re-syncs .skills/doctor.sh from the vendored source under skills-vendor/
+when the two differ, so upstream fixes reach consumers that did not
+install the auto-refresh hook. Best-effort — never affects the exit code;
+failures are reported only under --verbose. The refresh applies from the
+following run. Skipped entirely under --check-only, which makes no writes.
+
 When submodule init fails with a well-known SSH/HTTPS auth signature
 (Permission denied, Could not read from remote repository, Authentication
 failed for 'https://'), a targeted remediation block is printed instead
@@ -59,14 +72,15 @@ the agent isn't reachable from this shell. A separate remediation block
 covers host-key-verification failures (ssh-keyscan-based fix).
 
 Options:
-  --check-only    Report broken symlinks but do not run submodule init
-                  (overridden by the archive-checkout path when .git is
-                  absent — the archive case prints its own diagnosis).
+  --check-only    Report broken symlinks but make no changes: no submodule
+                  init, no self-sync. (The archive-checkout path when .git
+                  is absent overrides the reporting, printing its own
+                  diagnosis — it makes no changes either.)
   --no-preflight  Skip the SSH pre-flight ping. Useful when the operator
                   knows the agent state and doesn't want the 3-second
                   ConnectTimeout on every invocation.
   --verbose, -v   Print resolution details even when healthy.
-  --version       Print script version and exit.
+  --version       Print the script's diagnostic version stamp and exit.
   --help, -h      Show this help and exit.
 
 Exit codes:
@@ -89,6 +103,83 @@ done
 # root, but we tolerate being called from a subdirectory.
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
+
+# Re-sync the installed copy of this script from the vendored source.
+#
+# The doctor is installed as a real file rather than a symlink so it stays
+# reachable when the vendor submodule is uninitialized — the exact state it
+# exists to repair. The cost of that choice is drift: upstream fixes reach a
+# consumer only when something re-runs install-doctor.sh. The auto-refresh
+# hook does that each session, but consumers that declined the hook would
+# otherwise run a stale doctor indefinitely (issue #84). Since every
+# reviewing-* / shipping-* preflight invokes the doctor, this is the one code
+# path guaranteed to run in a hook-less consumer.
+#
+# The vendored copy is authoritative and CONTENT decides, not mtime. Git sets
+# mtimes at checkout time, so a freshly-initialized submodule always looks
+# "newer" and a deliberate submodule rollback always looks "older" — an mtime
+# comparison misfires in both directions. Content equality also gives pinning
+# the right semantics: a consumer pinned to an older submodule gets that
+# older doctor, which is what pinning means.
+#
+# Wholly best-effort. A missing vendor, a missing installer, a destination
+# the installer refuses to clobber, or a failed copy must all leave this
+# script's exit code untouched: Phase 1 preflights invoke the doctor with
+# `|| exit 1`, so a self-sync failure would otherwise block a review over
+# something cosmetic.
+sync_self() {
+  # --check-only is contractually non-mutating — it is the mode a CI health
+  # probe reaches for, and .skills/doctor.sh is a tracked file, so a write
+  # here would dirty the working tree and trip a `git diff --exit-code`
+  # cleanliness gate on the next submodule bump, with nothing connecting the
+  # failure back to the bump.
+  if [ "$CHECK_ONLY" = "1" ]; then
+    return 0
+  fi
+
+  local self="$ROOT/.skills/doctor.sh"
+  # Only refresh an already-installed doctor — never create one. Installation
+  # is Step 2c's job (and the hook's); a preflight shouldn't materialize files
+  # the operator didn't ask for. In the preflight path this always exists,
+  # since that path tests `-x .skills/doctor.sh` before invoking us.
+  [ -f "$self" ] || return 0
+
+  local src installer out rc
+  # First matching vendor wins, matching skills-submodule-update.sh's `break`.
+  # When skills-vendor/ is absent the glob stays unexpanded and the -f test
+  # rejects the literal string, so the loop falls through to `return 0`.
+  for src in skills-vendor/*/skills/managing-skills/scripts/doctor.sh; do
+    [ -f "$src" ] || continue
+    if cmp -s "$src" "$self"; then
+      return 0
+    fi
+    installer="$(dirname "$src")/install-doctor.sh"
+    [ -f "$installer" ] || return 0
+
+    # Capture rather than discard. A permanently-failing sync is otherwise
+    # invisible: a consumer with a user-authored file at .skills/doctor.sh
+    # can never receive doctor updates, and the installer's precise
+    # explanation of why would go to /dev/null on every preflight forever.
+    # Surfaced only under --verbose so the default path stays quiet.
+    # `--quiet` means a successful run produces no output, so `out` is
+    # non-empty only when something went wrong.
+    rc=0
+    out="$(bash "$installer" --quiet 2>&1)" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      echo "doctor: refreshed .skills/doctor.sh from $src — the update applies from the next run" >&2
+    elif [ "$VERBOSE" = "1" ]; then
+      echo "doctor: self-sync failed (rc=$rc); the installed copy is unchanged:" >&2
+      printf '%s\n' "$out" >&2
+    fi
+    return 0
+  done
+  return 0
+}
+
+# Call site 1 of 2: the healthy path exits early a few lines below, which is
+# the overwhelming majority of invocations. A self-sync placed after the heal
+# logic would almost never run.
+sync_self
 
 # Nothing to check if the consumer doesn't use the skills/ pattern.
 if [ ! -d skills ]; then
@@ -332,6 +423,10 @@ if [ "$RC" -ne 0 ]; then
   fi
   exit 1
 fi
+
+# Call site 2 of 2: the vendor tree may have only just become readable — call
+# site 1 ran before the init and would have found nothing to sync against.
+sync_self
 
 # Re-check after self-heal.
 scan_broken

--- a/.socraticodecontextartifacts.json
+++ b/.socraticodecontextartifacts.json
@@ -7,8 +7,13 @@
     },
     {
       "name": "usps-api-spec",
-      "path": "./docs/usps-addresses-v3r2_3.yaml",
-      "description": "USPS Address Validation API v3 OpenAPI spec — upstream provider contract, request/response shapes, DPV fields."
+      "path": "./docs/usps-addresses-v3r2_4.yaml",
+      "description": "USPS Addresses API v3 OpenAPI spec (v3.2.3, pre-Enhanced) — legacy provider contract, request/response shapes, DPV fields. Superseded in production by usps-enhanced-api-spec; retained for comparison."
+    },
+    {
+      "name": "usps-enhanced-api-spec",
+      "path": "./docs/usps-enhanced-addresses-v3r2.yaml",
+      "description": "USPS Enhanced Addresses API OpenAPI spec (v3.3.1) — the contract live in production since 2026-08-01. Same servers and /address path as v3.2.3, DPVConfirmation/vacant retained, plus the additionalInfo indicator set."
     },
     {
       "name": "usps-pub28-reference",

--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -48,7 +48,14 @@ When a provider is rate-limited (HTTP 429 after all retries), the next provider 
 
 ## USPS provider
 
-- API: USPS Addresses API v3. Spec archived at `docs/usps-addresses-v3r2_4.yaml`.
+- API: USPS Addresses API v3. Spec archived at `docs/usps-addresses-v3r2_4.yaml`;
+  the Enhanced spec live in production is `docs/usps-enhanced-addresses-v3r2.yaml`.
+  **Vendoring a new spec revision is a two-file change** — add/replace the YAML *and*
+  repoint the matching entry in `.socraticodecontextartifacts.json`. A stale path there
+  is skipped silently by the SocratiCode server (short artifact count, no error), and
+  blocks `mcp-driver.mjs` until `INDEX_TIMEOUT_MS`. Verify with
+  `node skills-vendor/gregoryfoster-skills/skills/init-socraticode/scripts/mcp-driver.mjs validate-manifest .`
+  then re-run `codebase_context_index`.
 - Auth: OAuth2 client credentials. Token cached 55 min in-process (`asyncio.Lock` prevents concurrent refresh races).
 - Rate limit: multi-window quota guard — per-second soft window (default 5 req/s), per-day soft
   window (default 10 000/day). Configurable via `USPS_RATE_LIMIT_RPS` and `USPS_DAILY_LIMIT`.

--- a/tests/unit/test_context_artifacts_manifest.py
+++ b/tests/unit/test_context_artifacts_manifest.py
@@ -1,0 +1,48 @@
+"""Drift guard for the SocratiCode context-artifact manifest (GH #188).
+
+``.socraticodecontextartifacts.json`` declares the non-code knowledge sources
+the SocratiCode server indexes for `codebase_context*` search. A well-formed but
+non-resolving ``path`` is **skipped silently** — the server reports a short
+artifact count, not an error — so the manifest drifted for a full spec bump
+before anyone noticed the USPS API contract had stopped being searchable.
+
+This test is the cheap, dependency-free half of the upstream
+``mcp-driver.mjs validate-manifest`` check: every declared path must resolve.
+If you vendor a new revision of a spec or move a doc, repoint its entry here.
+"""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / ".socraticodecontextartifacts.json"
+
+
+def _artifacts() -> list[dict]:
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    return payload["artifacts"]
+
+
+def test_manifest_present_and_well_formed() -> None:
+    assert MANIFEST.is_file(), f"missing manifest: {MANIFEST}"
+    artifacts = _artifacts()
+    assert artifacts, "manifest declares no artifacts"
+    for artifact in artifacts:
+        assert artifact.get("name"), f"artifact without a name: {artifact}"
+        assert artifact.get("path"), f"artifact without a path: {artifact}"
+
+
+def test_every_artifact_path_resolves() -> None:
+    missing = [
+        f"{a['name']} -> {a['path']}" for a in _artifacts() if not (REPO_ROOT / a["path"]).exists()
+    ]
+    assert not missing, (
+        "context artifacts point at paths that do not exist — the SocratiCode "
+        "server skips these silently:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_artifact_names_are_unique() -> None:
+    names = [a["name"] for a in _artifacts()]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    assert not duplicates, f"duplicate artifact names: {duplicates}"


### PR DESCRIPTION
Closes #187. Closes #188.

Two independent infra fixes, one commit each.

## #187 — skills auto-refresh hook

`.skills/doctor.sh` was frozen at `VERSION=2026-05-28-6` because the legacy inline `UserPromptSubmit` hook bumped submodules but never called `install-doctor.sh`. That hook had also gone stale in a second way: it still referenced `vendor/gregoryfoster-skills` / `vendor/obra-superpowers`, paths that no longer exist since the rename to `skills-vendor/` — so it had been a no-op bump, running on every prompt, on any branch.

- Bump `skills-vendor/gregoryfoster-skills` `a6d9927` → `3fc7b71` (contains the self-syncing doctor, gregoryfoster/skills#84).
- Symlink `.claude/hooks/skills-submodule-update.sh` → vendored script; wire as `SessionStart`. `main`-only, once-per-UTC-day lock, log-bounded, scoped to `skills-vendor/`, always exits 0.
- Remove the legacy inline `UserPromptSubmit` entry — two mechanisms on one submodule is a race.
- Refresh `.skills/doctor.sh` to `2026-08-04-2` via `install-doctor.sh`.

The pre-existing `socraticode-reminder.sh` `SessionStart` entry is preserved (jq merge, not overwrite).

**Verify**
```
$ bash .skills/doctor.sh --version
2026-08-04-2
$ bash .claude/hooks/skills-submodule-update.sh; echo $?
0
```

## #188 — SocratiCode artifact manifest

`usps-api-spec` pointed at `./docs/usps-addresses-v3r2_3.yaml`, deleted when the spec was bumped to `_4`. A non-resolving path is skipped **silently** — 8/9 artifacts indexed, no error — and the one going missing was the USPS API contract.

- Repoint `usps-api-spec` → `./docs/usps-addresses-v3r2_4.yaml`.
- Add `usps-enhanced-api-spec` → `./docs/usps-enhanced-addresses-v3r2.yaml`. Separate contract (v3.3.1), live in production since 2026-08-01, and one artifact = one path.
- New `tests/unit/test_context_artifacts_manifest.py` — drift guard: every declared path resolves, names unique, entries well-formed. Dependency-free half of the upstream validator, so recurrence fails CI rather than degrading search quietly. Confirmed it fails on the exact `_3` path this PR fixes.
- `docs/VALIDATION-PROVIDERS.md`: spec-bump checklist now names the manifest.

**Verify**
```
$ node skills-vendor/gregoryfoster-skills/skills/init-socraticode/scripts/mcp-driver.mjs validate-manifest .
[driver] … — OK: 10 artifact(s), every path resolves
```

## Test status

`uv run pytest` — 1067 passed, coverage 95.17%. `ruff check` / `ruff format --check` clean; pre-commit passed on both commits.

## Follow-up after merge

`codebase_context_index` needs a re-run on `main` so the indexed count reaches 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)