### PR TITLE
#155 [docs]: USPS reinstated; canary re-watch Aug 7-8

### DIFF
--- a/docs/VALIDATION-PROVIDERS.md
+++ b/docs/VALIDATION-PROVIDERS.md
@@ -77,11 +77,12 @@ License executed 2026-07-06.** Design doc: `docs/plans/2026-07-02-usps-enhanced-
 `additionalInfo` indicators are recon targets (GH #122).
 
 **Canary:** `scripts/usps_canary.sh` — launch validated 2026-08-01 (Enhanced
-shape live on prod, zero changes needed); post-launch watch runs daily
-16:23 UTC August 2–6 via crontab (`23 16 2-6 8 *`). Probes OAuth, a live
-`/address` call (cache bypassed, no DB writes), both vendored spec checksums,
-and portal spec links; comments on GH #155 on anomaly. Remove the crontab
-entry after August 6.
+shape live on prod, zero changes needed). USPS was disabled Aug 2–6 (billing
+freeze) then reinstated 2026-08-06; a short post-reinstatement watch runs
+daily 16:23 UTC August 7–8 via crontab (`23 16 7-8 8 *`). Probes OAuth, a
+live `/address` call (cache bypassed, no DB writes), both vendored spec
+checksums, and portal spec links; comments on GH #155 on anomaly. Remove the
+crontab entry after August 8.
 
 If USPS starts rejecting our OAuth credentials (401/403 → `ProviderBadRequestError`,
 logged as operator-action-required) before the license is executed:

--- a/scripts/usps_canary.sh
+++ b/scripts/usps_canary.sh
@@ -2,8 +2,9 @@
 # USPS Enhanced Addresses API switch canary — GH #155.
 #
 # Daily crontab probe for the 2026-08-01 licensing switch. Launch validated
-# 2026-08-01; post-launch watch window trimmed to Aug 2-6 per operator:
-#   23 16 2-6 8 * /home/exedev/address-validator/scripts/usps_canary.sh
+# 2026-08-01. USPS was disabled Aug 2-6 (billing freeze) then reinstated
+# 2026-08-06; short post-reinstatement watch Aug 7-8 per operator:
+#   23 16 7-8 8 * /home/exedev/address-validator/scripts/usps_canary.sh
 #
 # Probes (all bypass the service cache; nothing is written to the prod DB):
 #   1. OAuth2 token endpoint with production creds


### PR DESCRIPTION
USPS was disabled Aug 2–6 (billing freeze) then reinstated as primary 2026-08-06 (verified live: `provider=usps`, DPV `Y`, fresh USPS call in journal). The original Aug 2–6 post-launch watch never ran against live USPS, so per operator a short re-watch runs Aug 7–8. Crontab updated on the VM (`23 16 7-8 8 *`); script header + runbook synced. Removal deadline now Aug 8.

Part of #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)